### PR TITLE
update instance configs with patch changes

### DIFF
--- a/ScoutHelper/Config/Configuration.cs
+++ b/ScoutHelper/Config/Configuration.cs
@@ -25,6 +25,7 @@ public class Configuration : IPluginConfiguration {
 	public string CopyTemplate { get; set; } = Constants.DefaultCopyTemplate;
 	public bool IsCopyModeFullText { get; set; } = false;
 
+	public DateTime LastInstancePatchUpdate = DateTime.UnixEpoch;
 	public Dictionary<uint, uint> Instances { get; set; } = new();
 
 	public void Initialize(DalamudPluginInterface pluginInterface) {

--- a/ScoutHelper/Constants.cs
+++ b/ScoutHelper/Constants.cs
@@ -1,5 +1,8 @@
-﻿using System.Net.Http.Headers;
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http.Headers;
 using System.Reflection;
+using ScoutHelper.Models;
 
 namespace ScoutHelper;
 
@@ -17,6 +20,9 @@ public static class Constants {
 	public const string DefaultCopyTemplate = "{patch} {#}/{#max} {world} [{tracker}]({link})";
 	public const string BearDataFile = @"Data\Bear.json";
 	public const string SirenDataFile = @"Data\Siren.json";
+
+	public static readonly DateTime LatestPatchUpdate = DateTime.Parse("2024-01-01T00:00:00Z");
+	public static readonly (Territory, uint)[] LatestPatchInstances = {};
 
 	#endregion
 

--- a/ScoutHelper/Managers/SirenManager.cs
+++ b/ScoutHelper/Managers/SirenManager.cs
@@ -154,7 +154,7 @@ public class SirenManager {
 			.MobOrder
 			.BindResults(
 				mapMobs => territoryManager
-					.GetTerritoryId(mapMobs.Map)
+					.FindTerritoryId(mapMobs.Map)
 					.ToResult<uint, string>($"No mapId found for mapName: {mapMobs.Map}")
 					.Map(
 						mapId => mapMobs
@@ -194,7 +194,7 @@ public class SirenManager {
 			)
 			.SelectResults(
 				mapData => territoryManager
-					.GetTerritoryId(mapData.mapName)
+					.FindTerritoryId(mapData.mapName)
 					.Select(id => (id, mapData.spawnPoints))
 					.ToResult($"No territoryId found for territoryName: {mapData.mapName}")
 			)

--- a/ScoutHelper/Managers/TerritoryManager.cs
+++ b/ScoutHelper/Managers/TerritoryManager.cs
@@ -27,7 +27,11 @@ public class TerritoryManager {
 		(_nameToId, _idToName) = LoadData(dataManager);
 	}
 
-	public Maybe<uint> GetTerritoryId(string territoryName) => _nameToId.MaybeGet(territoryName.Lower());
+	public Maybe<uint> FindTerritoryId(string territoryName) => _nameToId.MaybeGet(territoryName.Lower());
+
+	public Result<uint, string> GetTerritoryId(string territoryName) =>
+		FindTerritoryId(territoryName)
+			.ToResult<uint, string>($"Failed to find a territoryId for map name: {territoryName}");
 
 	public Maybe<string> GetTerritoryName(uint territoryId) =>
 		_idToName
@@ -41,6 +45,7 @@ public class TerritoryManager {
 
 		var supportedMapNames = GetEnumValues<Patch>()
 			.SelectMany(patch => patch.HuntMaps())
+			.Select(map => map.Name())
 			.ToImmutableHashSet();
 
 		var supportedPlaceIds = dataManager.GetExcelSheet<PlaceName>(ClientLanguage.English)!

--- a/ScoutHelper/Models/Territory.cs
+++ b/ScoutHelper/Models/Territory.cs
@@ -1,0 +1,82 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using static ScoutHelper.Models.Territory;
+using static ScoutHelper.Utils.Utils;
+
+namespace ScoutHelper.Models;
+
+public enum Territory {
+	// HW
+	CoerthasWesternHighlands,
+	TheSeaOfClouds,
+	AzysLla,
+	TheDravanianForelands,
+	TheDravanianHinterlands,
+	TheChurningMists,
+
+	// SB
+	TheFringes,
+	ThePeaks,
+	TheLochs,
+	TheRubySea,
+	Yanxia,
+	TheAzimSteppe,
+
+	// SHB
+	Lakeland,
+	Kholusia,
+	AmhAraeng,
+	IlMheg,
+	TheRaktikaGreatwood,
+	TheTempest,
+
+	// EW
+	Labyrinthos,
+	Thavnair,
+	Garlemald,
+	MareLamentorum,
+	Elpis,
+	UltimaThule,
+}
+
+public static class TerritoryExtensions {
+	private static readonly IDictionary<Territory, string> TerritoryNames = new Dictionary<Territory, string>() {
+		{ CoerthasWesternHighlands, "coerthas western highlands" },
+		{ TheSeaOfClouds, "the sea of clouds" },
+		{ AzysLla, "azys lla" },
+		{ TheDravanianForelands, "the dravanian forelands" },
+		{ TheDravanianHinterlands, "the dravanian hinterlands" },
+		{ TheChurningMists, "the churning mists" },
+
+		{ TheFringes, "the fringes" },
+		{ ThePeaks, "the peaks" },
+		{ TheLochs, "the lochs" },
+		{ TheRubySea, "the ruby sea" },
+		{ Yanxia, "yanxia" },
+		{ TheAzimSteppe, "the azim steppe" },
+
+		{ Lakeland, "lakeland" },
+		{ Kholusia, "kholusia" },
+		{ AmhAraeng, "amh araeng" },
+		{ IlMheg, "il mheg" },
+		{ TheRaktikaGreatwood, "the rak'tika greatwood" },
+		{ TheTempest, "the tempest" },
+
+		{ Labyrinthos, "labyrinthos" },
+		{ Thavnair, "thavnair" },
+		{ Garlemald, "garlemald" },
+		{ MareLamentorum, "mare lamentorum" },
+		{ Elpis, "elpis" },
+		{ UltimaThule, "ultima thule" },
+	}.VerifyEnumDictionary();
+
+	private static readonly IDictionary<Territory, uint> TerritoryInstances = GetEnumValues<Territory>()
+		.Select(territory => (territory, 1U))
+		.Concat(Constants.LatestPatchInstances)
+		.ToDict()
+		.VerifyEnumDictionary();
+
+	public static string Name(this Territory territory) => TerritoryNames[territory];
+	
+	public static uint Instances(this Territory territory) => TerritoryInstances[territory];
+}

--- a/ScoutHelper/Utils/Utils.cs
+++ b/ScoutHelper/Utils/Utils.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Numerics;
 using System.Text;
 using System.Text.RegularExpressions;
 using ImGuiNET;
 using Lumina.Text;
 using ScoutHelper.Models;
+using static ScoutHelper.Models.Territory;
 
 namespace ScoutHelper.Utils;
 
@@ -124,41 +126,41 @@ public static partial class Utils {
 }
 
 public static class UtilExtensions {
-	private static readonly IDictionary<Patch, uint> PatchMaxMarks = new Dictionary<Patch, uint>() {
-		{ Patch.ARR, 17 },
-		{ Patch.HW, 12 },
-		{ Patch.SB, 12 },
-		{ Patch.SHB, 12 },
-		{ Patch.EW, 16 },
-	}.VerifyEnumDictionary();
+	private static readonly IDictionary<Patch, IList<Territory>> PatchHuntMaps = new (Patch, IList<Territory>)[] {
+			(Patch.ARR, Array.Empty<Territory>()), // TODO: add arr maps
+			(Patch.HW, new[] {
+				CoerthasWesternHighlands, TheSeaOfClouds, AzysLla,
+				TheDravanianForelands, TheDravanianHinterlands, TheChurningMists,
+			}),
+			(Patch.SB, new[] {
+				TheFringes, ThePeaks, TheLochs,
+				TheRubySea, Yanxia, TheAzimSteppe,
+			}),
+			(Patch.SHB, new[] {
+				Lakeland, Kholusia, AmhAraeng,
+				IlMheg, TheRaktikaGreatwood, TheTempest,
+			}),
+			(Patch.EW, new[] {
+				Labyrinthos, Thavnair, Garlemald,
+				MareLamentorum, Elpis, UltimaThule,
+			}),
+		}
+		.Select(patch => (patch.Item1, patch.Item2.AsList()))
+		.ToDict()
+		.VerifyEnumDictionary();
 
-	private static readonly IDictionary<Patch, IList<string>> PatchHuntMaps = new Dictionary<Patch, IList<string>>() {
-		{
-			Patch.ARR, new List<string>() { }
-		}, {
-			Patch.HW, new List<string>() {
-				"coerthas western highlands", "the sea of clouds", "azys lla",
-				"the dravanian forelands", "the dravanian hinterlands", "the churning mists",
-			}
-		}, {
-			Patch.SB, new List<string>() {
-				"the fringes", "the peaks", "the lochs",
-				"the ruby sea", "yanxia", "the azim steppe",
-			}
-		}, {
-			Patch.SHB, new List<string>() {
-				"lakeland", "kholusia", "amh araeng",
-				"il mheg", "the rak'tika greatwood", "the tempest",
-			}
-		}, {
-			Patch.EW, new List<string>() {
-				"labyrinthos", "thavnair", "garlemald",
-				"mare lamentorum", "elpis", "ultima thule",
-			}
-		},
-	}.VerifyEnumDictionary();
+	private static readonly IDictionary<Patch, uint> PatchMaxMarks = PatchHuntMaps
+		.Select(
+			patchMaps => (
+				patchMaps.Key,
+				(uint)patchMaps.Value.Sum(territory => 2 * territory.Instances())
+			)
+		)
+		.Append((Patch.ARR, 17U))
+		.ToDict()
+		.VerifyEnumDictionary();
+
+	public static IList<Territory> HuntMaps(this Patch patch) => PatchHuntMaps[patch];
 
 	public static uint MaxMarks(this Patch patch) => PatchMaxMarks[patch];
-
-	public static IList<string> HuntMaps(this Patch patch) => PatchHuntMaps[patch];
 }

--- a/ScoutHelper/Windows/ConfigWindow.cs
+++ b/ScoutHelper/Windows/ConfigWindow.cs
@@ -132,8 +132,8 @@ public class ConfigWindow : Window, IDisposable {
 		patch
 			.HuntMaps()
 			.ForEach(
-				mapName => _territoryManager
-					.GetTerritoryId(mapName)
+				map => _territoryManager
+					.FindTerritoryId(map.Name())
 					.Select(
 						mapId => ImGui.InputScalar(
 							" " + _territoryManager.GetTerritoryName(mapId).Value,


### PR DESCRIPTION
- added a mechanism for overwriting people's instance customizations when a new patch update comes out. for now, this requires a plugin release with the new values.
- added a reset button in the instance config for if a user wants to reset their customizations back to the current patch values.