### PR TITLE
consolidate http request handling, and use api urls fresh every time

### DIFF
--- a/ScoutHelper/Models/Http/HttpError.cs
+++ b/ScoutHelper/Models/Http/HttpError.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Threading.Tasks;
 using CSharpFunctionalExtensions;
+using Dalamud.Plugin.Services;
 
 namespace ScoutHelper.Models.Http;
 
@@ -15,4 +17,35 @@ public enum HttpErrorType {
 	Timeout,
 	Canceled,
 	HttpException,
+}
+
+public static class HttpErrorExtensions {
+	public static Task<Result<T, string>> HandleHttpError<T>(
+		this Task<Result<T, HttpError>> apiOperation,
+		IPluginLog log,
+		string timeoutMsg,
+		string cancelMsg,
+		string httpExceptionMsg,
+		string unknownErrorMsg
+	) =>
+		apiOperation.MapError<T, HttpError, string>(
+			error => {
+				switch (error.ErrorType) {
+					case HttpErrorType.Timeout: {
+						log.Error(timeoutMsg);
+						return timeoutMsg;
+					}
+					case HttpErrorType.Canceled: {
+						log.Warning(cancelMsg);
+						return cancelMsg;
+					}
+					case HttpErrorType.HttpException:
+						log.Error(error.Exception, httpExceptionMsg);
+						return httpExceptionMsg;
+					default:
+						log.Error(error.Exception, unknownErrorMsg);
+						return unknownErrorMsg;
+				}
+			}
+		);
 }


### PR DESCRIPTION
api urls were loaded into each manager's httpclient in the constructors. this resulted in tweaks to the urls not actually changing which url was used, until the plugin is reloaded. this also introduced a problem where if the url is invalid, then the plugin will fail to load outright, and the user will have to manually edit save data to fix the url. so obviously both of those things suck XD
