### PR TITLE
Stop using Hunt Helper to detect A ranks and do it ourselves

### DIFF
--- a/ScoutHelper/Managers/HuntHelperManager.cs
+++ b/ScoutHelper/Managers/HuntHelperManager.cs
@@ -44,7 +44,7 @@ public class HuntHelperManager : IDisposable {
 		CheckVersion();
 		_cgEnable.Subscribe(OnEnable);
 		_cgDisable.Subscribe(OnDisable);
-		_cgMarkSeen.Subscribe(OnMarkSeen);
+		//_cgMarkSeen.Subscribe(OnMarkSeen);
 	}
 
 	public void Dispose() {
@@ -83,29 +83,7 @@ public class HuntHelperManager : IDisposable {
 	}
 
 	private void OnMarkSeen(TrainMob mark) {
-		if (!_turtleManager.IsTurtleCollabbing) return;
-
-		_turtleManager.UpdateCurrentSession(mark.AsSingletonList())
-			.ContinueWith(
-				task => {
-					switch (task.Result) {
-						case TurtleHttpStatus.Success:
-							_chat.TaggedPrint($"added {mark.Name} to the turtle session.");
-							break;
-						case TurtleHttpStatus.NoSupportedMobs:
-							_chat.TaggedPrint($"{mark.Name} was seen, but is not supported by turtle and will not be added to the session.");
-							break;
-						case TurtleHttpStatus.HttpError:
-							_chat.TaggedPrintError($"something went wrong when adding {mark.Name} to the turtle session ;-;.");
-							break;
-					}
-				},
-				TaskContinuationOptions.OnlyOnRanToCompletion
-			)
-			.ContinueWith(
-				task => _log.Error(task.Exception, "failed to update turtle session"),
-				TaskContinuationOptions.OnlyOnFaulted
-			);
+		_turtleManager.OnMarkSeen(mark);
 	}
 
 	public Result<List<TrainMob>, string> GetTrainList() {

--- a/ScoutHelper/Managers/HuntHelperManager.cs
+++ b/ScoutHelper/Managers/HuntHelperManager.cs
@@ -26,10 +26,10 @@ public class HuntHelperManager : IDisposable {
 	public bool Available { get; private set; } = false;
 
 	public HuntHelperManager(
-			IDalamudPluginInterface pluginInterface,
-			IPluginLog log,
-			IChatGui chat,
-			TurtleManager turtleManager
+		IDalamudPluginInterface pluginInterface,
+		IPluginLog log,
+		IChatGui chat,
+		TurtleManager turtleManager
 	) {
 		_log = log;
 		_chat = chat;
@@ -70,9 +70,9 @@ public class HuntHelperManager : IDisposable {
 				Available = true;
 			} else {
 				_log.Warning(
-						"Hunt Helper IPC version {0} required, but version {1} detected. Disabling support.",
-						SupportedVersion,
-						version
+					"Hunt Helper IPC version {0} required, but version {1} detected. Disabling support.",
+					SupportedVersion,
+					version
 				);
 				Available = false;
 			}
@@ -95,7 +95,7 @@ public class HuntHelperManager : IDisposable {
 			return _cgGetTrainList.InvokeFunc();
 		} catch (IpcNotReadyError) {
 			_log.Warning(
-					"Hunt Helper appears to have disappeared ;-;. Can't get the train data ;-;. Disabling support until it comes back."
+				"Hunt Helper appears to have disappeared ;-;. Can't get the train data ;-;. Disabling support until it comes back."
 			);
 			Available = false;
 			return "Hunt Helper has disappeared from my sight ;-;";

--- a/ScoutHelper/Managers/HuntHelperManager.cs
+++ b/ScoutHelper/Managers/HuntHelperManager.cs
@@ -1,4 +1,4 @@
-﻿using CSharpFunctionalExtensions;
+using CSharpFunctionalExtensions;
 using Dalamud.Plugin.Ipc;
 using Dalamud.Plugin.Ipc.Exceptions;
 using ScoutHelper.Models;
@@ -26,10 +26,10 @@ public class HuntHelperManager : IDisposable {
 	public bool Available { get; private set; } = false;
 
 	public HuntHelperManager(
-		IDalamudPluginInterface pluginInterface,
-		IPluginLog log,
-		IChatGui chat,
-		TurtleManager turtleManager
+			IDalamudPluginInterface pluginInterface,
+			IPluginLog log,
+			IChatGui chat,
+			TurtleManager turtleManager
 	) {
 		_log = log;
 		_chat = chat;
@@ -70,9 +70,9 @@ public class HuntHelperManager : IDisposable {
 				Available = true;
 			} else {
 				_log.Warning(
-					"Hunt Helper IPC version {0} required, but version {1} detected. Disabling support.",
-					SupportedVersion,
-					version
+						"Hunt Helper IPC version {0} required, but version {1} detected. Disabling support.",
+						SupportedVersion,
+						version
 				);
 				Available = false;
 			}
@@ -95,7 +95,7 @@ public class HuntHelperManager : IDisposable {
 			return _cgGetTrainList.InvokeFunc();
 		} catch (IpcNotReadyError) {
 			_log.Warning(
-				"Hunt Helper appears to have disappeared ;-;. Can't get the train data ;-;. Disabling support until it comes back."
+					"Hunt Helper appears to have disappeared ;-;. Can't get the train data ;-;. Disabling support until it comes back."
 			);
 			Available = false;
 			return "Hunt Helper has disappeared from my sight ;-;";

--- a/ScoutHelper/Managers/HuntMarkManager.cs
+++ b/ScoutHelper/Managers/HuntMarkManager.cs
@@ -1,4 +1,4 @@
-﻿using CSharpFunctionalExtensions;
+using CSharpFunctionalExtensions;
 using System;
 using System.Collections.Generic;
 using Dalamud.Plugin;
@@ -8,33 +8,33 @@ using XIVHuntUtils.Models;
 using System.Linq;
 using System.Numerics;
 using FFXIVClientStructs.FFXIV.Client.Game.UI;
+using static XIVHuntUtils.Utils.XivUtils;
 
 namespace ScoutHelper.Managers;
 using MobDict = IDictionary<uint, (Patch patch, uint turtleMobId)>;
 public class HuntMarkManager : IDisposable {
 
-    private readonly IFramework _framework;
+	private readonly IFramework _framework;
 	private readonly IObjectTable _objectTable;
-    private readonly IClientState _clientState;
-    private readonly IPluginLog _log;
+	private readonly IClientState _clientState;
+	private readonly IPluginLog _log;
 	private readonly IChatGui _chat;
 
-    private TimeSpan _lastUpdate = new(0);
-    private TimeSpan _execDelay = new(0, 0, 1);
+	private TimeSpan _lastUpdate = new(0);
+	private TimeSpan _execDelay = new(0, 0, 1);
 
 	private List<uint> _ARankbNPCIds = new();
 	private List<uint> _sentARankIds = new();
 
-    public event Action<ScoutHelper.Models.TrainMob> OnMarkFound;
+	public event Action<ScoutHelper.Models.TrainMob> OnMarkFound;
 
-    public HuntMarkManager(
-		IDalamudPluginInterface pluginInterface,
-		IFramework framework,
-		IObjectTable objectTable,
-        IClientState clientState,
-        IPluginLog log,
-		IChatGui chat
-	) {
+	public HuntMarkManager(
+				IFramework framework,
+				IPluginLog log,
+				IChatGui chat,
+				IClientState clientState,
+				IObjectTable objectTable
+		) {
 		_framework = framework;
 		_log = log;
 		_chat = chat;
@@ -42,120 +42,97 @@ public class HuntMarkManager : IDisposable {
 		_objectTable = objectTable;
 	}
 
-    private static float ConvertToMapCoordinate(float pos, float mapScale)
-    {
-        return 2048f / mapScale + pos / 50f + 1f;
-    }
-    private static Vector2 ConvertToMapCoordinate(Vector3 pos, float mapScale)
-    {
-        return new Vector2(
-            ConvertToMapCoordinate(pos.X, mapScale),
-            ConvertToMapCoordinate(pos.Z, mapScale)
-        );
-    }
-    private float GetMapZoneScale(uint territoryId)
-    {
-        //EVERYTHING EXCEPT HEAVENSWARD HAS A SCALE OF 100, BUT FOR SOME REASON HW HAS 95
-        if (territoryId is >= 397 and <= 402) return 95f;
-        return 100f;
-    }
+	private bool IsHWTerritory(uint territoryId) {
+		//EVERYTHING EXCEPT HEAVENSWARD HAS A SCALE OF 100, BUT FOR SOME REASON HW HAS 95
+		if (territoryId is >= 397 and <= 402) return true;
+		return false;
+	}
 
-	private unsafe uint GetCurrentInstance()
-	{
+	private unsafe uint GetCurrentInstance() {
 		return UIState.Instance()->PublicInstance.InstanceId;
 	}
 
-    private void CheckObjectTable()
-    {
-        foreach (var obj in _objectTable)
-        {
-            if (obj is not IBattleNpc mob) continue;
-            var battlenpc = mob as IBattleNpc;			
-			
-            if (_ARankbNPCIds.Contains(battlenpc.NameId))
-            {
-				if(_sentARankIds.Contains(battlenpc.NameId))
-				{
-                    //_log.Debug($"Got that A already...");
-                    continue;
+	private void CheckObjectTable() {
+		foreach (var obj in _objectTable) {
+			if (obj is not IBattleNpc mob) continue;
+			var battlenpc = mob as IBattleNpc;
+
+			if (_ARankbNPCIds.Contains(battlenpc.NameId)) {
+				if (_sentARankIds.Contains(battlenpc.NameId)) {
+					//_log.Debug($"Got that A already...");
+					continue;
 				}
 				var trainMob = new ScoutHelper.Models.TrainMob();
-				
+
 				trainMob.Name = battlenpc.Name.ToString();
 				trainMob.MobId = battlenpc.NameId;
 				trainMob.TerritoryId = _clientState.TerritoryType;
 				//trainMob.MapId =
 				trainMob.Instance = GetCurrentInstance();
-                trainMob.Position = ConvertToMapCoordinate(battlenpc.Position, GetMapZoneScale(trainMob.TerritoryId));
+				trainMob.Position = XIVHuntUtils.Utils.XivUtils.AsMapPosition(new Vector2(trainMob.Position.X, trainMob.Position.Z), IsHWTerritory(trainMob.TerritoryId));
 				trainMob.Dead = battlenpc.IsDead;
-                //trainMob.LastSeenUtc = 
-                _log.Debug($"I spy with my little eye: {trainMob.Name} ({trainMob.MobId}) in {trainMob.TerritoryId} i{trainMob.Instance} @{trainMob.Position} Dead?{trainMob.Dead}");
+				//trainMob.LastSeenUtc = 
+				_log.Debug($"I spy with my little eye: {trainMob.Name} ({trainMob.MobId}) in {trainMob.TerritoryId} i{trainMob.Instance} @{trainMob.Position} Dead?{trainMob.Dead}");
 				OnMarkFound.Invoke(trainMob);
 				_sentARankIds.Add(trainMob.MobId);
-            }
-        }
-    }
+			}
+		}
+	}
 
-    private void Tick(IFramework framework)
-    {
-        _lastUpdate += framework.UpdateDelta;
-        if (_lastUpdate > _execDelay)
-        {
-            DoUpdate(framework);
-            _lastUpdate = new(0);
-        }
-    }
+	private void Tick(IFramework framework) {
+		_lastUpdate += framework.UpdateDelta;
+		if (_lastUpdate > _execDelay) {
+			DoUpdate(framework);
+			_lastUpdate = new(0);
+		}
+	}
 
-	private void DoUpdate(IFramework framework)
-	{
-		//_log.Debug("HMM: UPDAATE!");
+	private void DoUpdate(IFramework framework) {
 		CheckObjectTable();
 	}
 
-    public void StartLooking(MobDict MobIdToTurtleId)
-	{
+	public void StartLooking(MobDict MobIdToTurtleId) {
 		_log.Debug("HuntMarkManager: Start looking for Ranks");
-        _ARankbNPCIds = MobIdToTurtleId.Keys.ToList();
+		_ARankbNPCIds = MobIdToTurtleId.Keys.ToList();
 		_sentARankIds = new();
-        _framework.Update += Tick;
-    }
+		_framework.Update += Tick;
+	}
 
-	public void StopLooking()
-	{
-        _log.Debug("HuntMarkManager: Stop looking for Ranks");
-        _framework.Update -= Tick;
-    }
+	public void StopLooking() {
+		_log.Debug("HuntMarkManager: Stop looking for Ranks");
+		_framework.Update -= Tick;
+	}
 
 	public void Dispose() {
 		_framework.Update -= Tick;
 	}
 
 	/*
-	private void OnMarkSeen(TrainMob mark) {
-		if (!_turtleManager.IsTurtleCollabbing) return;
+private void OnMarkSeen(TrainMob mark) {
+	if (!_turtleManager.IsTurtleCollabbing) return;
 
-		_turtleManager.UpdateCurrentSession(mark.AsSingletonList())
-			.ContinueWith(
-				task => {
-					switch (task.Result) {
-						case TurtleHttpStatus.Success:
-							_chat.TaggedPrint($"added {mark.Name} to the turtle session.");
-							break;
-						case TurtleHttpStatus.NoSupportedMobs:
-							_chat.TaggedPrint($"{mark.Name} was seen, but is not supported by turtle and will not be added to the session.");
-							break;
-						case TurtleHttpStatus.HttpError:
-							_chat.TaggedPrintError($"something went wrong when adding {mark.Name} to the turtle session ;-;.");
-							break;
-					}
-				},
-				TaskContinuationOptions.OnlyOnRanToCompletion
-			)
-			.ContinueWith(
-				task => _log.Error(task.Exception, "failed to update turtle session"),
-				TaskContinuationOptions.OnlyOnFaulted
-			);
-	}
-	*/
+	_turtleManager.UpdateCurrentSession(mark.AsSingletonList())
+		.ContinueWith(
+			task => {
+				switch (task.Result) {
+					case TurtleHttpStatus.Success:
+						_chat.TaggedPrint($"added {mark.Name} to the turtle session.");
+						break;
+					case TurtleHttpStatus.NoSupportedMobs:
+						_chat.TaggedPrint($"{mark.Name} was seen, but is not supported by turtle and will not be added to the session.");
+						break;
+					case TurtleHttpStatus.HttpError:
+						_chat.TaggedPrintError($"something went wrong when adding {mark.Name} to the turtle session ;-;.");
+						break;
+				}
+			},
+			TaskContinuationOptions.OnlyOnRanToCompletion
+		)
+		.ContinueWith(
+			task => _log.Error(task.Exception, "failed to update turtle session"),
+			TaskContinuationOptions.OnlyOnFaulted
+		);
+}
+*/
 
 }

--- a/ScoutHelper/Managers/HuntMarkManager.cs
+++ b/ScoutHelper/Managers/HuntMarkManager.cs
@@ -9,10 +9,13 @@ using System.Linq;
 using System.Numerics;
 using FFXIVClientStructs.FFXIV.Client.Game.UI;
 using static XIVHuntUtils.Utils.XivUtils;
+using Lumina.Excel.Sheets;
 
 namespace ScoutHelper.Managers;
 using MobDict = IDictionary<uint, (Patch patch, uint turtleMobId)>;
 public class HuntMarkManager : IDisposable {
+
+	private static readonly TimeSpan _execDelay = TimeSpan.FromSeconds(1);
 
 	private readonly IFramework _framework;
 	private readonly IObjectTable _objectTable;
@@ -20,8 +23,7 @@ public class HuntMarkManager : IDisposable {
 	private readonly IPluginLog _log;
 	private readonly IChatGui _chat;
 
-	private TimeSpan _lastUpdate = new(0);
-	private TimeSpan _execDelay = new(0, 0, 1);
+	private TimeSpan _lastUpdate = TimeSpan.FromSeconds(0);
 
 	private List<uint> _ARankbNPCIds = new();
 	private List<uint> _sentARankIds = new();
@@ -69,7 +71,7 @@ public class HuntMarkManager : IDisposable {
 				trainMob.TerritoryId = _clientState.TerritoryType;
 				//trainMob.MapId =
 				trainMob.Instance = GetCurrentInstance();
-				trainMob.Position = XIVHuntUtils.Utils.XivUtils.AsMapPosition(new Vector2(trainMob.Position.X, trainMob.Position.Z), IsHWTerritory(trainMob.TerritoryId));
+				trainMob.Position = XIVHuntUtils.Utils.XivUtils.AsMapPosition(new Vector2(battlenpc.Position.X, battlenpc.Position.Z), IsHWTerritory(trainMob.TerritoryId));
 				trainMob.Dead = battlenpc.IsDead;
 				//trainMob.LastSeenUtc = 
 				_log.Debug($"I spy with my little eye: {trainMob.Name} ({trainMob.MobId}) in {trainMob.TerritoryId} i{trainMob.Instance} @{trainMob.Position} Dead?{trainMob.Dead}");
@@ -106,33 +108,4 @@ public class HuntMarkManager : IDisposable {
 	public void Dispose() {
 		_framework.Update -= Tick;
 	}
-
-	/*
-private void OnMarkSeen(TrainMob mark) {
-	if (!_turtleManager.IsTurtleCollabbing) return;
-
-	_turtleManager.UpdateCurrentSession(mark.AsSingletonList())
-		.ContinueWith(
-			task => {
-				switch (task.Result) {
-					case TurtleHttpStatus.Success:
-						_chat.TaggedPrint($"added {mark.Name} to the turtle session.");
-						break;
-					case TurtleHttpStatus.NoSupportedMobs:
-						_chat.TaggedPrint($"{mark.Name} was seen, but is not supported by turtle and will not be added to the session.");
-						break;
-					case TurtleHttpStatus.HttpError:
-						_chat.TaggedPrintError($"something went wrong when adding {mark.Name} to the turtle session ;-;.");
-						break;
-				}
-			},
-			TaskContinuationOptions.OnlyOnRanToCompletion
-		)
-		.ContinueWith(
-			task => _log.Error(task.Exception, "failed to update turtle session"),
-			TaskContinuationOptions.OnlyOnFaulted
-		);
-}
-*/
-
 }

--- a/ScoutHelper/Managers/HuntMarkManager.cs
+++ b/ScoutHelper/Managers/HuntMarkManager.cs
@@ -16,7 +16,7 @@ namespace ScoutHelper.Managers;
 using MobDict = IDictionary<uint, (Patch patch, uint turtleMobId)>;
 
 public class HuntMarkManager : IDisposable {
-	private static readonly TimeSpan _execDelay = TimeSpan.FromSeconds(1);
+	private static readonly TimeSpan ExecDelay = TimeSpan.FromSeconds(1);
 
 	private readonly IFramework _framework;
 	private readonly IObjectTable _objectTable;
@@ -29,7 +29,7 @@ public class HuntMarkManager : IDisposable {
 	private List<uint> _ARankbNPCIds = new();
 	private List<uint> _sentARankIds = new();
 
-	public event Action<ScoutHelper.Models.TrainMob> OnMarkFound;
+	public event Action<ScoutHelper.Models.TrainMob>? OnMarkFound;
 
 	public HuntMarkManager(
 		IFramework framework,
@@ -81,7 +81,7 @@ public class HuntMarkManager : IDisposable {
 				_log.Debug(
 					$"I spy with my little eye: {trainMob.Name} ({trainMob.MobId}) in {trainMob.TerritoryId} i{trainMob.Instance} @{trainMob.Position} Dead?{trainMob.Dead}"
 				);
-				OnMarkFound.Invoke(trainMob);
+				OnMarkFound?.Invoke(trainMob);
 				_sentARankIds.Add(trainMob.MobId);
 			}
 		}
@@ -89,7 +89,7 @@ public class HuntMarkManager : IDisposable {
 
 	private void Tick(IFramework framework) {
 		_lastUpdate += framework.UpdateDelta;
-		if (_lastUpdate > _execDelay) {
+		if (_lastUpdate > ExecDelay) {
 			DoUpdate(framework);
 			_lastUpdate = new(0);
 		}
@@ -99,9 +99,9 @@ public class HuntMarkManager : IDisposable {
 		CheckObjectTable();
 	}
 
-	public void StartLooking(MobDict MobIdToTurtleId) {
+	public void StartLooking(MobDict mobIdToTurtleId) {
 		_log.Debug("HuntMarkManager: Start looking for Ranks");
-		_ARankbNPCIds = MobIdToTurtleId.Keys.ToList();
+		_ARankbNPCIds = mobIdToTurtleId.Keys.ToList();
 		_sentARankIds = new();
 		_framework.Update += Tick;
 	}

--- a/ScoutHelper/Managers/HuntMarkManager.cs
+++ b/ScoutHelper/Managers/HuntMarkManager.cs
@@ -1,0 +1,153 @@
+﻿using CSharpFunctionalExtensions;
+using System;
+using System.Collections.Generic;
+using Dalamud.Plugin;
+using Dalamud.Plugin.Services;
+using Dalamud.Game.ClientState.Objects.Types;
+using XIVHuntUtils.Models;
+using System.Linq;
+using System.Numerics;
+using FFXIVClientStructs.FFXIV.Client.Game.UI;
+
+namespace ScoutHelper.Managers;
+using MobDict = IDictionary<uint, (Patch patch, uint turtleMobId)>;
+public class HuntMarkManager : IDisposable {
+
+    private readonly IFramework _framework;
+	private readonly IObjectTable _objectTable;
+    private readonly IClientState _clientState;
+    private readonly IPluginLog _log;
+	private readonly IChatGui _chat;
+
+    private TimeSpan _lastUpdate = new(0);
+    private TimeSpan _execDelay = new(0, 0, 1);
+
+	private List<uint> _ARankbNPCIds = new();
+
+    public event Action<ScoutHelper.Models.TrainMob> OnMarkFound;
+
+    public HuntMarkManager(
+		IDalamudPluginInterface pluginInterface,
+		IFramework framework,
+		IObjectTable objectTable,
+        IClientState clientState,
+        IPluginLog log,
+		IChatGui chat
+	) {
+		_framework = framework;
+		_log = log;
+		_chat = chat;
+		_clientState = clientState;
+		_objectTable = objectTable;
+	}
+
+    private static float ConvertToMapCoordinate(float pos, float mapScale)
+    {
+        return 2048f / mapScale + pos / 50f + 1f;
+    }
+    private static Vector2 ConvertToMapCoordinate(Vector3 pos, float mapScale)
+    {
+        return new Vector2(
+            ConvertToMapCoordinate(pos.X, mapScale),
+            ConvertToMapCoordinate(pos.Z, mapScale)
+        );
+    }
+    private float GetMapZoneScale(ushort territoryId)
+    {
+        //EVERYTHING EXCEPT HEAVENSWARD HAS A SCALE OF 100, BUT FOR SOME REASON HW HAS 95
+        if (territoryId is >= 397 and <= 402) return 95f;
+        return 100f;
+    }
+
+	private unsafe uint GetCurrentInstance()
+	{
+		return UIState.Instance()->PublicInstance.InstanceId;
+	}
+
+    private void CheckObjectTable()
+    {
+        foreach (var obj in _objectTable)
+        {
+            if (obj is not IBattleNpc mob) continue;
+            var battlenpc = mob as IBattleNpc;			
+			
+            if (_ARankbNPCIds.Contains(battlenpc.NameId))
+            {
+				var trainMob = new ScoutHelper.Models.TrainMob();
+				
+				trainMob.Name = battlenpc.Name.ToString();
+				trainMob.MobId = battlenpc.NameId;
+				trainMob.TerritoryId = _clientState.TerritoryType;
+				//trainMob.MapId =
+				trainMob.Instance = GetCurrentInstance();
+                trainMob.Position = ConvertToMapCoordinate(battlenpc.Position, trainMob.TerritoryId);
+				trainMob.Dead = battlenpc.IsDead;
+                //trainMob.LastSeenUtc = 
+                _log.Debug($"I spy with my little eye: {trainMob.Name} ({trainMob.MobId}) in {trainMob.TerritoryId} i{trainMob.Instance} @{trainMob.Position} Dead?{trainMob.Dead}");
+				OnMarkFound.Invoke(trainMob);
+            }
+        }
+    }
+
+    private void Tick(IFramework framework)
+    {
+        _lastUpdate += framework.UpdateDelta;
+        if (_lastUpdate > _execDelay)
+        {
+            DoUpdate(framework);
+            _lastUpdate = new(0);
+        }
+    }
+
+	private void DoUpdate(IFramework framework)
+	{
+		//_log.Debug("HMM: UPDAATE!");
+		CheckObjectTable();
+	}
+
+    public void StartLooking(MobDict MobIdToTurtleId)
+	{
+		_log.Debug("HuntMarkManager: Start looking for Ranks");
+        _ARankbNPCIds = MobIdToTurtleId.Keys.ToList();
+        _framework.Update += Tick;
+    }
+
+	public void StopLooking()
+	{
+        _log.Debug("HuntMarkManager: Stop looking for Ranks");
+        _framework.Update -= Tick;
+    }
+
+	public void Dispose() {
+		_framework.Update -= Tick;
+	}
+
+	/*
+	private void OnMarkSeen(TrainMob mark) {
+		if (!_turtleManager.IsTurtleCollabbing) return;
+
+		_turtleManager.UpdateCurrentSession(mark.AsSingletonList())
+			.ContinueWith(
+				task => {
+					switch (task.Result) {
+						case TurtleHttpStatus.Success:
+							_chat.TaggedPrint($"added {mark.Name} to the turtle session.");
+							break;
+						case TurtleHttpStatus.NoSupportedMobs:
+							_chat.TaggedPrint($"{mark.Name} was seen, but is not supported by turtle and will not be added to the session.");
+							break;
+						case TurtleHttpStatus.HttpError:
+							_chat.TaggedPrintError($"something went wrong when adding {mark.Name} to the turtle session ;-;.");
+							break;
+					}
+				},
+				TaskContinuationOptions.OnlyOnRanToCompletion
+			)
+			.ContinueWith(
+				task => _log.Error(task.Exception, "failed to update turtle session"),
+				TaskContinuationOptions.OnlyOnFaulted
+			);
+	}
+	*/
+
+}

--- a/ScoutHelper/Managers/HuntMarkManager.cs
+++ b/ScoutHelper/Managers/HuntMarkManager.cs
@@ -12,9 +12,10 @@ using static XIVHuntUtils.Utils.XivUtils;
 using Lumina.Excel.Sheets;
 
 namespace ScoutHelper.Managers;
-using MobDict = IDictionary<uint, (Patch patch, uint turtleMobId)>;
-public class HuntMarkManager : IDisposable {
 
+using MobDict = IDictionary<uint, (Patch patch, uint turtleMobId)>;
+
+public class HuntMarkManager : IDisposable {
 	private static readonly TimeSpan _execDelay = TimeSpan.FromSeconds(1);
 
 	private readonly IFramework _framework;
@@ -31,12 +32,12 @@ public class HuntMarkManager : IDisposable {
 	public event Action<ScoutHelper.Models.TrainMob> OnMarkFound;
 
 	public HuntMarkManager(
-				IFramework framework,
-				IPluginLog log,
-				IChatGui chat,
-				IClientState clientState,
-				IObjectTable objectTable
-		) {
+		IFramework framework,
+		IPluginLog log,
+		IChatGui chat,
+		IClientState clientState,
+		IObjectTable objectTable
+	) {
 		_framework = framework;
 		_log = log;
 		_chat = chat;
@@ -71,10 +72,15 @@ public class HuntMarkManager : IDisposable {
 				trainMob.TerritoryId = _clientState.TerritoryType;
 				//trainMob.MapId =
 				trainMob.Instance = GetCurrentInstance();
-				trainMob.Position = XIVHuntUtils.Utils.XivUtils.AsMapPosition(new Vector2(battlenpc.Position.X, battlenpc.Position.Z), IsHWTerritory(trainMob.TerritoryId));
+				trainMob.Position = XIVHuntUtils.Utils.XivUtils.AsMapPosition(
+					new Vector2(battlenpc.Position.X, battlenpc.Position.Z),
+					IsHWTerritory(trainMob.TerritoryId)
+				);
 				trainMob.Dead = battlenpc.IsDead;
-				//trainMob.LastSeenUtc = 
-				_log.Debug($"I spy with my little eye: {trainMob.Name} ({trainMob.MobId}) in {trainMob.TerritoryId} i{trainMob.Instance} @{trainMob.Position} Dead?{trainMob.Dead}");
+				//trainMob.LastSeenUtc =
+				_log.Debug(
+					$"I spy with my little eye: {trainMob.Name} ({trainMob.MobId}) in {trainMob.TerritoryId} i{trainMob.Instance} @{trainMob.Position} Dead?{trainMob.Dead}"
+				);
 				OnMarkFound.Invoke(trainMob);
 				_sentARankIds.Add(trainMob.MobId);
 			}

--- a/ScoutHelper/Managers/TurtleManager.cs
+++ b/ScoutHelper/Managers/TurtleManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -31,8 +31,8 @@ public partial class TurtleManager : IDisposable {
 	private static partial Regex CollabLinkRegex();
 
 	private readonly IPluginLog _log;
-    private readonly IChatGui _chat;
-    private readonly Configuration _conf;
+	private readonly IChatGui _chat;
+	private readonly Configuration _conf;
 	private readonly IClientState _clientState;
 	private readonly HuntMarkManager _huntMarkManager;
 	private readonly HttpClientGenerator _httpClientGenerator;
@@ -46,14 +46,14 @@ public partial class TurtleManager : IDisposable {
 	public bool IsTurtleCollabbing { get; private set; } = false;
 
 	public TurtleManager(
-		IPluginLog log,
-        IChatGui chat,
-        Configuration conf,
-		IClientState clientState,
-		ScoutHelperOptions options,
-		TerritoryManager territoryManager,
-		HuntMarkManager huntMarkManager,
-		MobManager mobManager
+			IPluginLog log,
+			IChatGui chat,
+			Configuration conf,
+			IClientState clientState,
+			ScoutHelperOptions options,
+			TerritoryManager territoryManager,
+			HuntMarkManager huntMarkManager,
+			MobManager mobManager
 	) {
 		_log = log;
 		_chat = chat;
@@ -62,17 +62,17 @@ public partial class TurtleManager : IDisposable {
 		_huntMarkManager = huntMarkManager;
 
 		_httpClientGenerator = new HttpClientGenerator(
-			_log,
-			() => _conf.TurtleApiBaseUrl,
-			client => client.Timeout = _conf.TurtleApiTimeout
+				_log,
+				() => _conf.TurtleApiBaseUrl,
+				client => client.Timeout = _conf.TurtleApiTimeout
 		);
 
 		(MobIdToTurtleId, TerritoryIdToTurtleData)
-			= LoadData(options.TurtleDataFile, territoryManager, mobManager);
-        huntMarkManager.OnMarkFound += OnMarkSeen;
+				= LoadData(options.TurtleDataFile, territoryManager, mobManager);
+		huntMarkManager.OnMarkFound += OnMarkSeen;
 	}
 
-    public void Dispose() {
+	public void Dispose() {
 		_httpClientGenerator.Dispose();
 
 		GC.SuppressFinalize(this);
@@ -89,43 +89,40 @@ public partial class TurtleManager : IDisposable {
 		return (_currentCollabSession, _currentCollabPassword);
 	}
 
-    public void OnMarkSeen(TrainMob mark)
-    {
-        if (!IsTurtleCollabbing) return;
+	public void OnMarkSeen(TrainMob mark) {
+		if (!IsTurtleCollabbing) return;
 
-        UpdateCurrentSession(mark.AsSingletonList())
-            .ContinueWith(
-                task => {
-                    switch (task.Result)
-                    {
-                        case TurtleHttpStatus.Success:
-                            _chat.TaggedPrint($"added {mark.Name} to the turtle session.");
-                            break;
-                        case TurtleHttpStatus.NoSupportedMobs:
-                            _chat.TaggedPrint($"{mark.Name} was seen, but is not supported by turtle and will not be added to the session.");
-                            break;
-                        case TurtleHttpStatus.HttpError:
-                            _chat.TaggedPrintError($"something went wrong when adding {mark.Name} to the turtle session ;-;.");
-                            break;
-                    }
-                },
-                TaskContinuationOptions.OnlyOnRanToCompletion
-            )
-            .ContinueWith(
-                task => _log.Error(task.Exception, "failed to update turtle session"),
-                TaskContinuationOptions.OnlyOnFaulted
-            );
-    }
+		UpdateCurrentSession(mark.AsSingletonList())
+				.ContinueWith(
+						task => {
+							switch (task.Result) {
+								case TurtleHttpStatus.Success:
+									_chat.TaggedPrint($"added {mark.Name} to the turtle session.");
+									break;
+								case TurtleHttpStatus.NoSupportedMobs:
+									_chat.TaggedPrint($"{mark.Name} was seen, but is not supported by turtle and will not be added to the session.");
+									break;
+								case TurtleHttpStatus.HttpError:
+									_chat.TaggedPrintError($"something went wrong when adding {mark.Name} to the turtle session ;-;.");
+									break;
+							}
+						},
+						TaskContinuationOptions.OnlyOnRanToCompletion
+				)
+				.ContinueWith(
+						task => _log.Error(task.Exception, "failed to update turtle session"),
+						TaskContinuationOptions.OnlyOnFaulted
+				);
+	}
 
-    public void RejoinLastCollabSession() {
+	public void RejoinLastCollabSession() {
 		if (_currentCollabSession.IsNullOrEmpty() || _currentCollabPassword.IsNullOrEmpty())
 			throw new Exception("cannot rejoin the last turtle collab session as there is no last session.");
 		IsTurtleCollabbing = true;
-        _huntMarkManager.StartLooking(MobIdToTurtleId);
-    }
+		_huntMarkManager.StartLooking(MobIdToTurtleId);
+	}
 
-	public void LeaveCollabSession()
-	{
+	public void LeaveCollabSession() {
 		IsTurtleCollabbing = false;
 		_huntMarkManager.StopLooking();
 	}
@@ -136,43 +133,43 @@ public partial class TurtleManager : IDisposable {
 			return NoSupportedMobs;
 
 		var httpResult = await
-			HttpUtils.DoRequest(
-				_log,
-				new TurtleTrainUpdateRequest(
-					_currentCollabPassword,
-					_clientState.PlayerTag().Where(_ => _conf.IncludeNameInTurtleSession),
-					turtleSupportedMobs.Select(
-						mob =>
-							(TerritoryIdToTurtleData[mob.TerritoryId].TurtleId,
-								mob.Instance.AsTurtleInstance(),
-								MobIdToTurtleId[mob.MobId].turtleMobId,
-								mob.Position)
-					)
-				),
-				(content) => _httpClientGenerator.Client.PatchAsync(
-					$"{_conf.TurtleApiTrainPath}/{_currentCollabSession}",
-					content
-				)
-			).TapError(
-				error => {
-					if (error.ErrorType == HttpErrorType.Timeout) {
-						_log.Warning("timed out while trying to post updates to turtle session.");
-					} else if (error.ErrorType == HttpErrorType.Canceled) {
-						_log.Warning("operation canceled while trying to post updates to turtle session.");
-					} else if (error.ErrorType == HttpErrorType.HttpException) {
-						_log.Error(error.Exception, "http exception while trying to post updates to turtle session.");
-					} else {
-						_log.Error(error.Exception, "unknown exception while trying to post updates to turtle session.");
-					}
-				}
-			);
+				HttpUtils.DoRequest(
+						_log,
+						new TurtleTrainUpdateRequest(
+								_currentCollabPassword,
+								_clientState.PlayerTag().Where(_ => _conf.IncludeNameInTurtleSession),
+								turtleSupportedMobs.Select(
+										mob =>
+												(TerritoryIdToTurtleData[mob.TerritoryId].TurtleId,
+														mob.Instance.AsTurtleInstance(),
+														MobIdToTurtleId[mob.MobId].turtleMobId,
+														mob.Position)
+								)
+						),
+						(content) => _httpClientGenerator.Client.PatchAsync(
+								$"{_conf.TurtleApiTrainPath}/{_currentCollabSession}",
+								content
+						)
+				).TapError(
+						error => {
+							if (error.ErrorType == HttpErrorType.Timeout) {
+								_log.Warning("timed out while trying to post updates to turtle session.");
+							} else if (error.ErrorType == HttpErrorType.Canceled) {
+								_log.Warning("operation canceled while trying to post updates to turtle session.");
+							} else if (error.ErrorType == HttpErrorType.HttpException) {
+								_log.Error(error.Exception, "http exception while trying to post updates to turtle session.");
+							} else {
+								_log.Error(error.Exception, "unknown exception while trying to post updates to turtle session.");
+							}
+						}
+				);
 
 		return httpResult.IsSuccess ? Success : TurtleHttpStatus.HttpError;
 	}
 
 	public async Task<Result<TurtleLinkData, string>> GenerateTurtleLink(
-		IList<TrainMob> trainMobs,
-		bool allowEmpty = false
+			IList<TrainMob> trainMobs,
+			bool allowEmpty = false
 	) {
 		var turtleSupportedMobs = trainMobs.Where(mob => MobIdToTurtleId.ContainsKey(mob.MobId)).AsList();
 		if (!allowEmpty && turtleSupportedMobs.IsEmpty())
@@ -180,56 +177,56 @@ public partial class TurtleManager : IDisposable {
 
 		var spawnPoints = turtleSupportedMobs.SelectMaybe(GetRequestInfoForMob).ToList();
 		var highestPatch = allowEmpty
-			? Patch.DT
-			: turtleSupportedMobs
-				.Select(mob => MobIdToTurtleId[mob.MobId].patch)
-				.Max();
+				? Patch.DT
+				: turtleSupportedMobs
+						.Select(mob => MobIdToTurtleId[mob.MobId].patch)
+						.Max();
 
 		return await HttpUtils.DoRequest<TurtleTrainRequest, TurtleTrainResponse, TurtleLinkData>(
-				_log,
-				TurtleTrainRequest.CreateRequest(spawnPoints),
-				(content) => _httpClientGenerator.Client.PostAsync(_conf.TurtleApiTrainPath, content),
-				trainResponse => TurtleLinkData.From(trainResponse, highestPatch)
-			)
-			.HandleHttpError(
-				_log,
-				"timed out posting the train to turtle ;-;",
-				"generating the turtle link was canceled >_>",
-				"something failed when communicating with turtle :T",
-				"an unknown error happened while generating the turtle link D:"
-			);
+						_log,
+						TurtleTrainRequest.CreateRequest(spawnPoints),
+						(content) => _httpClientGenerator.Client.PostAsync(_conf.TurtleApiTrainPath, content),
+						trainResponse => TurtleLinkData.From(trainResponse, highestPatch)
+				)
+				.HandleHttpError(
+						_log,
+						"timed out posting the train to turtle ;-;",
+						"generating the turtle link was canceled >_>",
+						"something failed when communicating with turtle :T",
+						"an unknown error happened while generating the turtle link D:"
+				);
 	}
 
 	private Maybe<(uint mapId, uint instance, uint pointId, uint mobId)> GetRequestInfoForMob(TrainMob mob) =>
-		TerritoryIdToTurtleData
-			.MaybeGet(mob.TerritoryId)
-			.SelectMany(
-				mapData => GetNearestSpawnPoint(mob)
-					.Select(
-						nearestSpawnPoint => (
-							mapData.TurtleId,
-							mob.Instance.AsTurtleInstance(),
-							nearestSpawnPoint,
-							MobIdToTurtleId[mob.MobId].turtleMobId
-						)
-					)
-			);
+			TerritoryIdToTurtleData
+					.MaybeGet(mob.TerritoryId)
+					.SelectMany(
+							mapData => GetNearestSpawnPoint(mob)
+									.Select(
+											nearestSpawnPoint => (
+													mapData.TurtleId,
+													mob.Instance.AsTurtleInstance(),
+													nearestSpawnPoint,
+													MobIdToTurtleId[mob.MobId].turtleMobId
+											)
+									)
+					);
 
 	private Maybe<uint> GetNearestSpawnPoint(TrainMob mob) =>
-		TerritoryIdToTurtleData
-			.MaybeGet(mob.TerritoryId)
-			.Select(
-				territoryData => territoryData
-					.SpawnPoints
-					.AsPairs()
-					.MinBy(spawnPoint => (spawnPoint.val - mob.Position).LengthSquared())
-					.key
-			);
+			TerritoryIdToTurtleData
+					.MaybeGet(mob.TerritoryId)
+					.Select(
+							territoryData => territoryData
+									.SpawnPoints
+									.AsPairs()
+									.MinBy(spawnPoint => (spawnPoint.val - mob.Position).LengthSquared())
+									.key
+					);
 
 	private (MobDict, TerritoryDict) LoadData(
-		string dataFilePath,
-		TerritoryManager territoryManager,
-		MobManager mobManager
+			string dataFilePath,
+			TerritoryManager territoryManager,
+			MobManager mobManager
 	) {
 		_log.Debug("Loading Turtle data...");
 
@@ -243,65 +240,65 @@ public partial class TurtleManager : IDisposable {
 		}
 
 		var patchesData = data
-			.SelectMany(patchData => ParsePatchData(territoryManager, mobManager, patchData))
-			.WithValue(patchData => patchData.Unzip())
-			.ForEachError(error => { _log.Error(error); });
+				.SelectMany(patchData => ParsePatchData(territoryManager, mobManager, patchData))
+				.WithValue(patchData => patchData.Unzip())
+				.ForEachError(error => { _log.Error(error); });
 
 		var (mobIds, territories) = patchesData.Value;
 
 		return (
-			mobIds
-				.SelectMany(mobDict => mobDict.AsPairs())
-				.ToDict(),
-			territories
-				.SelectMany(territoryDict => territoryDict.AsPairs())
-				.ToDict()
+				mobIds
+						.SelectMany(mobDict => mobDict.AsPairs())
+						.ToDict(),
+				territories
+						.SelectMany(territoryDict => territoryDict.AsPairs())
+						.ToDict()
 		);
 	}
 
 	private static
-		AccumulatedResults<(MobDict, TerritoryDict), string> ParsePatchData(
-			TerritoryManager territoryManager,
-			MobManager mobManager,
-			KeyValuePair<string, TurtleJsonPatchData> patchData
-		) {
+			AccumulatedResults<(MobDict, TerritoryDict), string> ParsePatchData(
+					TerritoryManager territoryManager,
+					MobManager mobManager,
+					KeyValuePair<string, TurtleJsonPatchData> patchData
+			) {
 		if (!Enum.TryParse(patchData.Key.Upper(), out Patch patch)) {
 			throw new Exception($"Unknown patch: {patchData.Key}");
 		}
 
 		var parsedMobs = patchData
-			.Value
-			.Mobs
-			.SelectResults(
-				patchMob => mobManager
-					.GetMobId(patchMob.Key)
-					.Map(mobId => (mobId, (patch, patchMob.Value)))
-			)
-			.WithValue(mobs => mobs.ToDict());
+				.Value
+				.Mobs
+				.SelectResults(
+						patchMob => mobManager
+								.GetMobId(patchMob.Key)
+								.Map(mobId => (mobId, (patch, patchMob.Value)))
+				)
+				.WithValue(mobs => mobs.ToDict());
 
 		var parsedTerritories = patchData
-			.Value
-			.Maps
-			.SelectResults(
-				mapData => territoryManager
-					.FindTerritoryId(mapData.Key)
-					.ToResult<uint, string>($"No mapId found for mapName: {mapData.Key}")
-					.Map(
-						territoryId => {
-							var points = mapData
-								.Value
-								.Points
-								.Select(
-									pointData =>
-										(pointData.Key, V2(pointData.Value.X.AsFloat(), pointData.Value.Y.AsFloat()))
-								)
-								.ToDict();
+				.Value
+				.Maps
+				.SelectResults(
+						mapData => territoryManager
+								.FindTerritoryId(mapData.Key)
+								.ToResult<uint, string>($"No mapId found for mapName: {mapData.Key}")
+								.Map(
+										territoryId => {
+											var points = mapData
+															.Value
+															.Points
+															.Select(
+																	pointData =>
+																			(pointData.Key, V2(pointData.Value.X.AsFloat(), pointData.Value.Y.AsFloat()))
+															)
+															.ToDict();
 
-							return (territoryId, new TurtleMapData(mapData.Value.Id, points));
-						}
-					)
-			)
-			.WithValue(territoriesAsPairs => territoriesAsPairs.ToDict());
+											return (territoryId, new TurtleMapData(mapData.Value.Id, points));
+										}
+								)
+				)
+				.WithValue(territoriesAsPairs => territoriesAsPairs.ToDict());
 
 		return parsedMobs.JoinWith(parsedTerritories, (mobs, territories) => (mobs, territories));
 	}
@@ -314,20 +311,20 @@ public enum TurtleHttpStatus {
 }
 
 public record struct TurtleLinkData(
-	string Slug,
-	string CollabPassword,
-	string ReadonlyUrl,
-	string CollabUrl,
-	Patch HighestPatch
+		string Slug,
+		string CollabPassword,
+		string ReadonlyUrl,
+		string CollabUrl,
+		Patch HighestPatch
 ) {
 	public static TurtleLinkData From(TurtleTrainResponse response, Patch highestPatch) =>
-		new(
-			response.Slug,
-			response.CollaboratorPassword,
-			response.ReadonlyUrl,
-			response.CollaborateUrl,
-			highestPatch
-		);
+			new(
+					response.Slug,
+					response.CollaboratorPassword,
+					response.ReadonlyUrl,
+					response.CollaborateUrl,
+					highestPatch
+			);
 }
 
 public static class TurtleExtensions {

--- a/ScoutHelper/Managers/TurtleManager.cs
+++ b/ScoutHelper/Managers/TurtleManager.cs
@@ -69,11 +69,13 @@ public partial class TurtleManager : IDisposable {
 
 		(MobIdToTurtleId, TerritoryIdToTurtleData)
 			= LoadData(options.TurtleDataFile, territoryManager, mobManager);
-		huntMarkManager.OnMarkFound += OnMarkSeen;
+		_huntMarkManager.OnMarkFound += OnMarkSeen;
 	}
 
 	public void Dispose() {
 		_httpClientGenerator.Dispose();
+		_huntMarkManager.StopLooking();
+		_huntMarkManager.OnMarkFound -= OnMarkSeen;
 
 		GC.SuppressFinalize(this);
 	}

--- a/ScoutHelper/Managers/TurtleManager.cs
+++ b/ScoutHelper/Managers/TurtleManager.cs
@@ -46,14 +46,14 @@ public partial class TurtleManager : IDisposable {
 	public bool IsTurtleCollabbing { get; private set; } = false;
 
 	public TurtleManager(
-			IPluginLog log,
-			IChatGui chat,
-			Configuration conf,
-			IClientState clientState,
-			ScoutHelperOptions options,
-			TerritoryManager territoryManager,
-			HuntMarkManager huntMarkManager,
-			MobManager mobManager
+		IPluginLog log,
+		IChatGui chat,
+		Configuration conf,
+		IClientState clientState,
+		ScoutHelperOptions options,
+		TerritoryManager territoryManager,
+		HuntMarkManager huntMarkManager,
+		MobManager mobManager
 	) {
 		_log = log;
 		_chat = chat;
@@ -62,13 +62,13 @@ public partial class TurtleManager : IDisposable {
 		_huntMarkManager = huntMarkManager;
 
 		_httpClientGenerator = new HttpClientGenerator(
-				_log,
-				() => _conf.TurtleApiBaseUrl,
-				client => client.Timeout = _conf.TurtleApiTimeout
+			_log,
+			() => _conf.TurtleApiBaseUrl,
+			client => client.Timeout = _conf.TurtleApiTimeout
 		);
 
 		(MobIdToTurtleId, TerritoryIdToTurtleData)
-				= LoadData(options.TurtleDataFile, territoryManager, mobManager);
+			= LoadData(options.TurtleDataFile, territoryManager, mobManager);
 		huntMarkManager.OnMarkFound += OnMarkSeen;
 	}
 
@@ -93,26 +93,28 @@ public partial class TurtleManager : IDisposable {
 		if (!IsTurtleCollabbing) return;
 
 		UpdateCurrentSession(mark.AsSingletonList())
-				.ContinueWith(
-						task => {
-							switch (task.Result) {
-								case TurtleHttpStatus.Success:
-									_chat.TaggedPrint($"added {mark.Name} to the turtle session.");
-									break;
-								case TurtleHttpStatus.NoSupportedMobs:
-									_chat.TaggedPrint($"{mark.Name} was seen, but is not supported by turtle and will not be added to the session.");
-									break;
-								case TurtleHttpStatus.HttpError:
-									_chat.TaggedPrintError($"something went wrong when adding {mark.Name} to the turtle session ;-;.");
-									break;
-							}
-						},
-						TaskContinuationOptions.OnlyOnRanToCompletion
-				)
-				.ContinueWith(
-						task => _log.Error(task.Exception, "failed to update turtle session"),
-						TaskContinuationOptions.OnlyOnFaulted
-				);
+			.ContinueWith(
+				task => {
+					switch (task.Result) {
+						case TurtleHttpStatus.Success:
+							_chat.TaggedPrint($"added {mark.Name} to the turtle session.");
+							break;
+						case TurtleHttpStatus.NoSupportedMobs:
+							_chat.TaggedPrint(
+								$"{mark.Name} was seen, but is not supported by turtle and will not be added to the session."
+							);
+							break;
+						case TurtleHttpStatus.HttpError:
+							_chat.TaggedPrintError($"something went wrong when adding {mark.Name} to the turtle session ;-;.");
+							break;
+					}
+				},
+				TaskContinuationOptions.OnlyOnRanToCompletion
+			)
+			.ContinueWith(
+				task => _log.Error(task.Exception, "failed to update turtle session"),
+				TaskContinuationOptions.OnlyOnFaulted
+			);
 	}
 
 	public void RejoinLastCollabSession() {
@@ -133,43 +135,43 @@ public partial class TurtleManager : IDisposable {
 			return NoSupportedMobs;
 
 		var httpResult = await
-				HttpUtils.DoRequest(
-						_log,
-						new TurtleTrainUpdateRequest(
-								_currentCollabPassword,
-								_clientState.PlayerTag().Where(_ => _conf.IncludeNameInTurtleSession),
-								turtleSupportedMobs.Select(
-										mob =>
-												(TerritoryIdToTurtleData[mob.TerritoryId].TurtleId,
-														mob.Instance.AsTurtleInstance(),
-														MobIdToTurtleId[mob.MobId].turtleMobId,
-														mob.Position)
-								)
-						),
-						(content) => _httpClientGenerator.Client.PatchAsync(
-								$"{_conf.TurtleApiTrainPath}/{_currentCollabSession}",
-								content
-						)
-				).TapError(
-						error => {
-							if (error.ErrorType == HttpErrorType.Timeout) {
-								_log.Warning("timed out while trying to post updates to turtle session.");
-							} else if (error.ErrorType == HttpErrorType.Canceled) {
-								_log.Warning("operation canceled while trying to post updates to turtle session.");
-							} else if (error.ErrorType == HttpErrorType.HttpException) {
-								_log.Error(error.Exception, "http exception while trying to post updates to turtle session.");
-							} else {
-								_log.Error(error.Exception, "unknown exception while trying to post updates to turtle session.");
-							}
-						}
-				);
+			HttpUtils.DoRequest(
+				_log,
+				new TurtleTrainUpdateRequest(
+					_currentCollabPassword,
+					_clientState.PlayerTag().Where(_ => _conf.IncludeNameInTurtleSession),
+					turtleSupportedMobs.Select(
+						mob =>
+							(TerritoryIdToTurtleData[mob.TerritoryId].TurtleId,
+								mob.Instance.AsTurtleInstance(),
+								MobIdToTurtleId[mob.MobId].turtleMobId,
+								mob.Position)
+					)
+				),
+				(content) => _httpClientGenerator.Client.PatchAsync(
+					$"{_conf.TurtleApiTrainPath}/{_currentCollabSession}",
+					content
+				)
+			).TapError(
+				error => {
+					if (error.ErrorType == HttpErrorType.Timeout) {
+						_log.Warning("timed out while trying to post updates to turtle session.");
+					} else if (error.ErrorType == HttpErrorType.Canceled) {
+						_log.Warning("operation canceled while trying to post updates to turtle session.");
+					} else if (error.ErrorType == HttpErrorType.HttpException) {
+						_log.Error(error.Exception, "http exception while trying to post updates to turtle session.");
+					} else {
+						_log.Error(error.Exception, "unknown exception while trying to post updates to turtle session.");
+					}
+				}
+			);
 
 		return httpResult.IsSuccess ? Success : TurtleHttpStatus.HttpError;
 	}
 
 	public async Task<Result<TurtleLinkData, string>> GenerateTurtleLink(
-			IList<TrainMob> trainMobs,
-			bool allowEmpty = false
+		IList<TrainMob> trainMobs,
+		bool allowEmpty = false
 	) {
 		var turtleSupportedMobs = trainMobs.Where(mob => MobIdToTurtleId.ContainsKey(mob.MobId)).AsList();
 		if (!allowEmpty && turtleSupportedMobs.IsEmpty())
@@ -177,56 +179,56 @@ public partial class TurtleManager : IDisposable {
 
 		var spawnPoints = turtleSupportedMobs.SelectMaybe(GetRequestInfoForMob).ToList();
 		var highestPatch = allowEmpty
-				? Patch.DT
-				: turtleSupportedMobs
-						.Select(mob => MobIdToTurtleId[mob.MobId].patch)
-						.Max();
+			? Patch.DT
+			: turtleSupportedMobs
+				.Select(mob => MobIdToTurtleId[mob.MobId].patch)
+				.Max();
 
 		return await HttpUtils.DoRequest<TurtleTrainRequest, TurtleTrainResponse, TurtleLinkData>(
-						_log,
-						TurtleTrainRequest.CreateRequest(spawnPoints),
-						(content) => _httpClientGenerator.Client.PostAsync(_conf.TurtleApiTrainPath, content),
-						trainResponse => TurtleLinkData.From(trainResponse, highestPatch)
-				)
-				.HandleHttpError(
-						_log,
-						"timed out posting the train to turtle ;-;",
-						"generating the turtle link was canceled >_>",
-						"something failed when communicating with turtle :T",
-						"an unknown error happened while generating the turtle link D:"
-				);
+				_log,
+				TurtleTrainRequest.CreateRequest(spawnPoints),
+				(content) => _httpClientGenerator.Client.PostAsync(_conf.TurtleApiTrainPath, content),
+				trainResponse => TurtleLinkData.From(trainResponse, highestPatch)
+			)
+			.HandleHttpError(
+				_log,
+				"timed out posting the train to turtle ;-;",
+				"generating the turtle link was canceled >_>",
+				"something failed when communicating with turtle :T",
+				"an unknown error happened while generating the turtle link D:"
+			);
 	}
 
 	private Maybe<(uint mapId, uint instance, uint pointId, uint mobId)> GetRequestInfoForMob(TrainMob mob) =>
-			TerritoryIdToTurtleData
-					.MaybeGet(mob.TerritoryId)
-					.SelectMany(
-							mapData => GetNearestSpawnPoint(mob)
-									.Select(
-											nearestSpawnPoint => (
-													mapData.TurtleId,
-													mob.Instance.AsTurtleInstance(),
-													nearestSpawnPoint,
-													MobIdToTurtleId[mob.MobId].turtleMobId
-											)
-									)
-					);
+		TerritoryIdToTurtleData
+			.MaybeGet(mob.TerritoryId)
+			.SelectMany(
+				mapData => GetNearestSpawnPoint(mob)
+					.Select(
+						nearestSpawnPoint => (
+							mapData.TurtleId,
+							mob.Instance.AsTurtleInstance(),
+							nearestSpawnPoint,
+							MobIdToTurtleId[mob.MobId].turtleMobId
+						)
+					)
+			);
 
 	private Maybe<uint> GetNearestSpawnPoint(TrainMob mob) =>
-			TerritoryIdToTurtleData
-					.MaybeGet(mob.TerritoryId)
-					.Select(
-							territoryData => territoryData
-									.SpawnPoints
-									.AsPairs()
-									.MinBy(spawnPoint => (spawnPoint.val - mob.Position).LengthSquared())
-									.key
-					);
+		TerritoryIdToTurtleData
+			.MaybeGet(mob.TerritoryId)
+			.Select(
+				territoryData => territoryData
+					.SpawnPoints
+					.AsPairs()
+					.MinBy(spawnPoint => (spawnPoint.val - mob.Position).LengthSquared())
+					.key
+			);
 
 	private (MobDict, TerritoryDict) LoadData(
-			string dataFilePath,
-			TerritoryManager territoryManager,
-			MobManager mobManager
+		string dataFilePath,
+		TerritoryManager territoryManager,
+		MobManager mobManager
 	) {
 		_log.Debug("Loading Turtle data...");
 
@@ -240,65 +242,65 @@ public partial class TurtleManager : IDisposable {
 		}
 
 		var patchesData = data
-				.SelectMany(patchData => ParsePatchData(territoryManager, mobManager, patchData))
-				.WithValue(patchData => patchData.Unzip())
-				.ForEachError(error => { _log.Error(error); });
+			.SelectMany(patchData => ParsePatchData(territoryManager, mobManager, patchData))
+			.WithValue(patchData => patchData.Unzip())
+			.ForEachError(error => { _log.Error(error); });
 
 		var (mobIds, territories) = patchesData.Value;
 
 		return (
-				mobIds
-						.SelectMany(mobDict => mobDict.AsPairs())
-						.ToDict(),
-				territories
-						.SelectMany(territoryDict => territoryDict.AsPairs())
-						.ToDict()
+			mobIds
+				.SelectMany(mobDict => mobDict.AsPairs())
+				.ToDict(),
+			territories
+				.SelectMany(territoryDict => territoryDict.AsPairs())
+				.ToDict()
 		);
 	}
 
 	private static
-			AccumulatedResults<(MobDict, TerritoryDict), string> ParsePatchData(
-					TerritoryManager territoryManager,
-					MobManager mobManager,
-					KeyValuePair<string, TurtleJsonPatchData> patchData
-			) {
+		AccumulatedResults<(MobDict, TerritoryDict), string> ParsePatchData(
+			TerritoryManager territoryManager,
+			MobManager mobManager,
+			KeyValuePair<string, TurtleJsonPatchData> patchData
+		) {
 		if (!Enum.TryParse(patchData.Key.Upper(), out Patch patch)) {
 			throw new Exception($"Unknown patch: {patchData.Key}");
 		}
 
 		var parsedMobs = patchData
-				.Value
-				.Mobs
-				.SelectResults(
-						patchMob => mobManager
-								.GetMobId(patchMob.Key)
-								.Map(mobId => (mobId, (patch, patchMob.Value)))
-				)
-				.WithValue(mobs => mobs.ToDict());
+			.Value
+			.Mobs
+			.SelectResults(
+				patchMob => mobManager
+					.GetMobId(patchMob.Key)
+					.Map(mobId => (mobId, (patch, patchMob.Value)))
+			)
+			.WithValue(mobs => mobs.ToDict());
 
 		var parsedTerritories = patchData
-				.Value
-				.Maps
-				.SelectResults(
-						mapData => territoryManager
-								.FindTerritoryId(mapData.Key)
-								.ToResult<uint, string>($"No mapId found for mapName: {mapData.Key}")
-								.Map(
-										territoryId => {
-											var points = mapData
-															.Value
-															.Points
-															.Select(
-																	pointData =>
-																			(pointData.Key, V2(pointData.Value.X.AsFloat(), pointData.Value.Y.AsFloat()))
-															)
-															.ToDict();
-
-											return (territoryId, new TurtleMapData(mapData.Value.Id, points));
-										}
+			.Value
+			.Maps
+			.SelectResults(
+				mapData => territoryManager
+					.FindTerritoryId(mapData.Key)
+					.ToResult<uint, string>($"No mapId found for mapName: {mapData.Key}")
+					.Map(
+						territoryId => {
+							var points = mapData
+								.Value
+								.Points
+								.Select(
+									pointData =>
+										(pointData.Key, V2(pointData.Value.X.AsFloat(), pointData.Value.Y.AsFloat()))
 								)
-				)
-				.WithValue(territoriesAsPairs => territoriesAsPairs.ToDict());
+								.ToDict();
+
+							return (territoryId, new TurtleMapData(mapData.Value.Id, points));
+						}
+					)
+			)
+			.WithValue(territoriesAsPairs => territoriesAsPairs.ToDict());
 
 		return parsedMobs.JoinWith(parsedTerritories, (mobs, territories) => (mobs, territories));
 	}
@@ -311,20 +313,20 @@ public enum TurtleHttpStatus {
 }
 
 public record struct TurtleLinkData(
-		string Slug,
-		string CollabPassword,
-		string ReadonlyUrl,
-		string CollabUrl,
-		Patch HighestPatch
+	string Slug,
+	string CollabPassword,
+	string ReadonlyUrl,
+	string CollabUrl,
+	Patch HighestPatch
 ) {
 	public static TurtleLinkData From(TurtleTrainResponse response, Patch highestPatch) =>
-			new(
-					response.Slug,
-					response.CollaboratorPassword,
-					response.ReadonlyUrl,
-					response.CollaborateUrl,
-					highestPatch
-			);
+		new(
+			response.Slug,
+			response.CollaboratorPassword,
+			response.ReadonlyUrl,
+			response.CollaborateUrl,
+			highestPatch
+		);
 }
 
 public static class TurtleExtensions {

--- a/ScoutHelper/Plugin.cs
+++ b/ScoutHelper/Plugin.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using Dalamud.Game.Command;
@@ -29,14 +29,14 @@ public sealed class Plugin : IDalamudPlugin {
 	private readonly Action _dispose;
 
 	public Plugin(
-		IDalamudPluginInterface pluginInterface,
-		IFramework framework,
-		IObjectTable objectTable,
-		IPluginLog log,
-		IChatGui chatGui,
-		ICommandManager commandManager,
-		IClientState clientState,
-		IDataManager dataManager
+			IFramework framework,
+			IDalamudPluginInterface pluginInterface,
+			IPluginLog log,
+			IChatGui chatGui,
+			ICommandManager commandManager,
+			IClientState clientState,
+			IDataManager dataManager,
+			IObjectTable objectTable
 	) {
 		_log = log;
 
@@ -44,33 +44,33 @@ public sealed class Plugin : IDalamudPlugin {
 		conf.Initialize(_log, pluginInterface);
 
 		var serviceProvider = new ServiceCollection()
-			.AddSingleton(pluginInterface)
-            .AddSingleton(framework)
-            .AddSingleton(objectTable)
-            .AddSingleton(_log)
-			.AddSingleton(chatGui)
-			.AddSingleton(commandManager)
-			.AddSingleton(clientState)
-			.AddSingleton(dataManager)
-			.AddSingleton(conf)
-			.AddSingleton(
-				new ScoutHelperOptions(
-					pluginInterface.PluginFilePath(Constants.BearDataFile),
-					pluginInterface.PluginFilePath(Constants.SirenDataFile),
-					pluginInterface.PluginFilePath(Constants.TurtleDataFile)
+				.AddSingleton(framework)
+				.AddSingleton(pluginInterface)
+				.AddSingleton(_log)
+				.AddSingleton(chatGui)
+				.AddSingleton(commandManager)
+				.AddSingleton(clientState)
+				.AddSingleton(dataManager)
+				.AddSingleton(objectTable)
+				.AddSingleton(conf)
+				.AddSingleton(
+						new ScoutHelperOptions(
+								pluginInterface.PluginFilePath(Constants.BearDataFile),
+								pluginInterface.PluginFilePath(Constants.SirenDataFile),
+								pluginInterface.PluginFilePath(Constants.TurtleDataFile)
+						)
 				)
-			)
-			.AddSingleton<MobManager>()
-			.AddSingleton<TerritoryManager>()
-            .AddSingleton<HuntHelperManager>()
-            .AddSingleton<HuntMarkManager>()
-            .AddSingleton<BearManager>()
-			.AddSingleton<SirenManager>()
-			.AddSingleton<TurtleManager>()
-			.AddSingleton<ConfigWindow>()
-			.AddSingleton<MainWindow>()
-			.AddSingleton<InitializationManager>()
-			.BuildServiceProvider();
+				.AddSingleton<MobManager>()
+				.AddSingleton<TerritoryManager>()
+				.AddSingleton<HuntHelperManager>()
+				.AddSingleton<HuntMarkManager>()
+				.AddSingleton<BearManager>()
+				.AddSingleton<SirenManager>()
+				.AddSingleton<TurtleManager>()
+				.AddSingleton<ConfigWindow>()
+				.AddSingleton<MainWindow>()
+				.AddSingleton<InitializationManager>()
+				.BuildServiceProvider();
 
 		var initManager = serviceProvider.GetRequiredService<InitializationManager>();
 		initManager.InitializeNecessaryComponents();
@@ -84,8 +84,8 @@ public sealed class Plugin : IDalamudPlugin {
 		_windowSystem.AddWindow(_mainWindow);
 
 		CommandNames.ForEach(
-			commandName =>
-				commandManager.AddHandler(commandName, new CommandInfo(OnCommand) { HelpMessage = "Opens the main window." })
+				commandName =>
+						commandManager.AddHandler(commandName, new CommandInfo(OnCommand) { HelpMessage = "Opens the main window." })
 		);
 
 		pluginInterface.UiBuilder.Draw += DrawUi;

--- a/ScoutHelper/Plugin.cs
+++ b/ScoutHelper/Plugin.cs
@@ -30,6 +30,8 @@ public sealed class Plugin : IDalamudPlugin {
 
 	public Plugin(
 		IDalamudPluginInterface pluginInterface,
+		IFramework framework,
+		IObjectTable objectTable,
 		IPluginLog log,
 		IChatGui chatGui,
 		ICommandManager commandManager,
@@ -43,7 +45,9 @@ public sealed class Plugin : IDalamudPlugin {
 
 		var serviceProvider = new ServiceCollection()
 			.AddSingleton(pluginInterface)
-			.AddSingleton(_log)
+            .AddSingleton(framework)
+            .AddSingleton(objectTable)
+            .AddSingleton(_log)
 			.AddSingleton(chatGui)
 			.AddSingleton(commandManager)
 			.AddSingleton(clientState)
@@ -58,8 +62,9 @@ public sealed class Plugin : IDalamudPlugin {
 			)
 			.AddSingleton<MobManager>()
 			.AddSingleton<TerritoryManager>()
-			.AddSingleton<HuntHelperManager>()
-			.AddSingleton<BearManager>()
+            .AddSingleton<HuntHelperManager>()
+            .AddSingleton<HuntMarkManager>()
+            .AddSingleton<BearManager>()
 			.AddSingleton<SirenManager>()
 			.AddSingleton<TurtleManager>()
 			.AddSingleton<ConfigWindow>()

--- a/ScoutHelper/Plugin.cs
+++ b/ScoutHelper/Plugin.cs
@@ -29,14 +29,14 @@ public sealed class Plugin : IDalamudPlugin {
 	private readonly Action _dispose;
 
 	public Plugin(
-			IFramework framework,
-			IDalamudPluginInterface pluginInterface,
-			IPluginLog log,
-			IChatGui chatGui,
-			ICommandManager commandManager,
-			IClientState clientState,
-			IDataManager dataManager,
-			IObjectTable objectTable
+		IFramework framework,
+		IDalamudPluginInterface pluginInterface,
+		IPluginLog log,
+		IChatGui chatGui,
+		ICommandManager commandManager,
+		IClientState clientState,
+		IDataManager dataManager,
+		IObjectTable objectTable
 	) {
 		_log = log;
 
@@ -44,33 +44,33 @@ public sealed class Plugin : IDalamudPlugin {
 		conf.Initialize(_log, pluginInterface);
 
 		var serviceProvider = new ServiceCollection()
-				.AddSingleton(framework)
-				.AddSingleton(pluginInterface)
-				.AddSingleton(_log)
-				.AddSingleton(chatGui)
-				.AddSingleton(commandManager)
-				.AddSingleton(clientState)
-				.AddSingleton(dataManager)
-				.AddSingleton(objectTable)
-				.AddSingleton(conf)
-				.AddSingleton(
-						new ScoutHelperOptions(
-								pluginInterface.PluginFilePath(Constants.BearDataFile),
-								pluginInterface.PluginFilePath(Constants.SirenDataFile),
-								pluginInterface.PluginFilePath(Constants.TurtleDataFile)
-						)
+			.AddSingleton(framework)
+			.AddSingleton(pluginInterface)
+			.AddSingleton(_log)
+			.AddSingleton(chatGui)
+			.AddSingleton(commandManager)
+			.AddSingleton(clientState)
+			.AddSingleton(dataManager)
+			.AddSingleton(objectTable)
+			.AddSingleton(conf)
+			.AddSingleton(
+				new ScoutHelperOptions(
+					pluginInterface.PluginFilePath(Constants.BearDataFile),
+					pluginInterface.PluginFilePath(Constants.SirenDataFile),
+					pluginInterface.PluginFilePath(Constants.TurtleDataFile)
 				)
-				.AddSingleton<MobManager>()
-				.AddSingleton<TerritoryManager>()
-				.AddSingleton<HuntHelperManager>()
-				.AddSingleton<HuntMarkManager>()
-				.AddSingleton<BearManager>()
-				.AddSingleton<SirenManager>()
-				.AddSingleton<TurtleManager>()
-				.AddSingleton<ConfigWindow>()
-				.AddSingleton<MainWindow>()
-				.AddSingleton<InitializationManager>()
-				.BuildServiceProvider();
+			)
+			.AddSingleton<MobManager>()
+			.AddSingleton<TerritoryManager>()
+			.AddSingleton<HuntHelperManager>()
+			.AddSingleton<HuntMarkManager>()
+			.AddSingleton<BearManager>()
+			.AddSingleton<SirenManager>()
+			.AddSingleton<TurtleManager>()
+			.AddSingleton<ConfigWindow>()
+			.AddSingleton<MainWindow>()
+			.AddSingleton<InitializationManager>()
+			.BuildServiceProvider();
 
 		var initManager = serviceProvider.GetRequiredService<InitializationManager>();
 		initManager.InitializeNecessaryComponents();
@@ -84,8 +84,8 @@ public sealed class Plugin : IDalamudPlugin {
 		_windowSystem.AddWindow(_mainWindow);
 
 		CommandNames.ForEach(
-				commandName =>
-						commandManager.AddHandler(commandName, new CommandInfo(OnCommand) { HelpMessage = "Opens the main window." })
+			commandName =>
+				commandManager.AddHandler(commandName, new CommandInfo(OnCommand) { HelpMessage = "Opens the main window." })
 		);
 
 		pluginInterface.UiBuilder.Draw += DrawUi;

--- a/ScoutHelper/Windows/MainWindow.cs
+++ b/ScoutHelper/Windows/MainWindow.cs
@@ -32,12 +32,12 @@ public class MainWindow : Window, IDisposable {
 	private static readonly Vector4 DangerBgColor = Color(181, 0, 69);
 
 	private static readonly IList<(ImGuiCol, Vector4)> NoticeStyleColors = new[] {
-		(ImGuiCol.FrameBg, DangerBgColor),
-		(ImGuiCol.Button, DangerBgColor),
-		(ImGuiCol.ButtonHovered, DangerFgColor),
-		(ImGuiCol.Border, DangerFgColor),
-		(ImGuiCol.Text, DangerFgColor),
-	}.AsList();
+				(ImGuiCol.FrameBg, DangerBgColor),
+				(ImGuiCol.Button, DangerBgColor),
+				(ImGuiCol.ButtonHovered, DangerFgColor),
+				(ImGuiCol.Border, DangerFgColor),
+				(ImGuiCol.Text, DangerFgColor),
+		}.AsList();
 
 	private readonly IPluginLog _log;
 	private readonly IClientState _clientState;
@@ -68,18 +68,18 @@ public class MainWindow : Window, IDisposable {
 	private bool _closeTurtleCollabPopup = false;
 
 	public MainWindow(
-		IPluginLog log,
-		IClientState clientState,
-		Configuration conf,
-		IChatGui chat,
-		HuntHelperManager huntHelperManager,
-		BearManager bearManager,
-		SirenManager sirenManager,
-		TurtleManager turtleManager,
-		ConfigWindow configWindow
+			IPluginLog log,
+			IClientState clientState,
+			Configuration conf,
+			IChatGui chat,
+			HuntHelperManager huntHelperManager,
+			BearManager bearManager,
+			SirenManager sirenManager,
+			TurtleManager turtleManager,
+			ConfigWindow configWindow
 	) : base(
-		Strings.MainWindowTitle,
-		ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoScrollbar
+			Strings.MainWindowTitle,
+			ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoScrollbar
 	) {
 		_log = log;
 		_clientState = clientState;
@@ -99,71 +99,71 @@ public class MainWindow : Window, IDisposable {
 			MaximumSize = new Vector2(float.MaxValue, float.MaxValue),
 		};
 		TitleBarButtons.Add(
-			new TitleBarButton() {
-				Click = _ => _configWindow.IsOpen = true,
-				Icon = FontAwesomeIcon.Cog,
-				IconOffset = V2(2, 1),
-				ShowTooltip = () => ImGuiPlus.CreateTooltip("open the scout helper settings window"),
-			}
+				new TitleBarButton() {
+					Click = _ => _configWindow.IsOpen = true,
+					Icon = FontAwesomeIcon.Cog,
+					IconOffset = V2(2, 1),
+					ShowTooltip = () => ImGuiPlus.CreateTooltip("open the scout helper settings window"),
+				}
 		);
 
 		_buttonSize = new Lazy<Vector2>(
-			() => {
-				try {
-					var buttonSize = new[] {
-							[Strings.BearButton],
-							[Strings.SirenButton],
-							[Strings.TurtleButton, Strings.TurtleCollabButton],
-							new[] { Strings.CopyModeLinkButton, Strings.CopyModeFullTextButton, },
-						}
-						.Select(
-							labels => labels
-								.Select(ImGuiHelpers.GetButtonSize)
-								.Aggregate((a, b) => new Vector2(Math.Max(a.X, b.X), Math.Max(a.Y, b.Y)))
-						)
-						.MaxBy(size => size.X);
-					buttonSize.X += 4 * ImGui.GetFontSize(); // add some horizontal padding
-					return buttonSize;
-				} catch (Exception e) {
-					_log.Error(e, "error while determining button size.");
-					throw;
+				() => {
+					try {
+						var buttonSize = new[] {
+														[Strings.BearButton],
+														[Strings.SirenButton],
+														[Strings.TurtleButton, Strings.TurtleCollabButton],
+														new[] { Strings.CopyModeLinkButton, Strings.CopyModeFullTextButton, },
+										}
+										.Select(
+												labels => labels
+														.Select(ImGuiHelpers.GetButtonSize)
+														.Aggregate((a, b) => new Vector2(Math.Max(a.X, b.X), Math.Max(a.Y, b.Y)))
+										)
+										.MaxBy(size => size.X);
+						buttonSize.X += 4 * ImGui.GetFontSize(); // add some horizontal padding
+						return buttonSize;
+					} catch (Exception e) {
+						_log.Error(e, "error while determining button size.");
+						throw;
+					}
 				}
-			}
 		);
 
 		_notices = Constants.Notices;
 
 		_noticeFrameBorderSize = new Lazy<float>(() => ImGuiHelpers.GlobalScaleSafe * (NoticeHasBorder ? 1 : 0));
 		_noticeFrameWrap = new Lazy<float>(
-			() => new[] {
-				_buttonSize.Value.X,
-				-2 * ImGui.GetStyle().FramePadding.X,
-				-ImGui.CalcTextSize(NoticeBulletChar).X,
-			}.Sum()
+				() => new[] {
+								_buttonSize.Value.X,
+								-2 * ImGui.GetStyle().FramePadding.X,
+								-ImGui.CalcTextSize(NoticeBulletChar).X,
+				}.Sum()
 		);
 		var noticeAckButtonSize = new Lazy<Vector2>(() => ImGuiHelpers.GetButtonSize(Strings.MainWindowNoticesAck));
 		_noticeFrameHeight = new Lazy<float>(
-			() => new[] {
-				2 * ImGui.GetStyle().FramePadding.Y,
-				ImGui.CalcTextSize(Strings.MainWindowSectionLabelNotices).Y,
-				4 * ImGui.GetStyle().ItemSpacing.Y,
-				noticeAckButtonSize.Value.Y,
-				2 * _noticeFrameBorderSize.Value,
-				_notices
-					.Select(
-						notice =>
-							ImGui.CalcTextSize(notice, _noticeFrameWrap.Value).Y
-							+ ImGui.GetStyle().ItemSpacing.Y
-					)
-					.Sum(),
-			}.Sum()
+				() => new[] {
+								2 * ImGui.GetStyle().FramePadding.Y,
+								ImGui.CalcTextSize(Strings.MainWindowSectionLabelNotices).Y,
+								4 * ImGui.GetStyle().ItemSpacing.Y,
+								noticeAckButtonSize.Value.Y,
+								2 * _noticeFrameBorderSize.Value,
+								_notices
+										.Select(
+												notice =>
+														ImGui.CalcTextSize(notice, _noticeFrameWrap.Value).Y
+														+ ImGui.GetStyle().ItemSpacing.Y
+										)
+										.Sum(),
+				}.Sum()
 		);
 		_noticeAckButtonPos = new Lazy<Vector2>(
-			() => V2(
-				(_buttonSize.Value.X - noticeAckButtonSize.Value.X) / 2,
-				_noticeFrameHeight.Value - noticeAckButtonSize.Value.Y - ImGui.GetStyle().FramePadding.Y -
-				2 * _noticeFrameBorderSize.Value
-			)
+				() => V2(
+						(_buttonSize.Value.X - noticeAckButtonSize.Value.X) / 2,
+						_noticeFrameHeight.Value - noticeAckButtonSize.Value.Y - ImGui.GetStyle().FramePadding.Y -
+						2 * _noticeFrameBorderSize.Value
+				)
 		);
 
 		_latestNoticesAreAcknowledged = Constants.LatestNoticeUpdate < _conf.LastNoticeAcknowledged;
@@ -193,71 +193,71 @@ public class MainWindow : Window, IDisposable {
 		var textColor = *ImGui.GetStyleColorVec4(ImGuiCol.Text);
 
 		ImGuiPlus
-			.WithStyle(NoticeStyleColors)
-			.Do(
-				() => {
-					var startedChildFrame = ImGui.BeginChildFrame(
-						ImGui.GetID("notice panel"),
-						_buttonSize.Value.WithY(_noticeFrameHeight.Value),
-						ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse | ImGuiWindowFlags.AlwaysAutoResize
-					);
-					if (!startedChildFrame) return;
-
-					ImGuiHelpers.CenteredText(Strings.MainWindowSectionLabelNotices);
-					ImGuiPlus
-						.WithStyle(ImGuiStyleVar.CellPadding, V2(0, 0))
-						.Do(
-							() => {
-								if (!ImGui.BeginTable("notices", 2, ImGuiTableFlags.SizingFixedFit))
-									return;
-
-								_notices.ForEach(
-									notice => {
-										ImGui.TableNextRow();
-										ImGui.TableNextColumn();
-										ImGui.Text(NoticeBulletChar);
-
-										ImGui.TableNextColumn();
-										ImGui.PushTextWrapPos(_noticeFrameWrap.Value + ImGui.GetCursorPosX());
-										ImGui.TextWrapped(notice);
-										ImGui.PopTextWrapPos();
-									}
-								);
-
-								ImGui.EndTable();
-							}
-						);
-
-					ImGui.Dummy(2 * V2(0, ImGui.GetStyle().ItemSpacing.Y));
-					ImGuiPlus
-						.WithStyle(ImGuiCol.Text, _noticeAckButtonColor)
-						.WithStyle(ImGuiStyleVar.FrameBorderSize, _noticeFrameBorderSize.Value)
-						.Do(
-							() => {
-								ImGui.SetCursorPos(_noticeAckButtonPos.Value);
-								if (!ImGui.Button(Strings.MainWindowNoticesAck)) return;
-
-								_conf.LastNoticeAcknowledged = DateTime.UtcNow;
-								_conf.Save();
-								_latestNoticesAreAcknowledged = true;
-							}
-						);
-					ImGuiPlus.WithStyle(ImGuiCol.Text, textColor).Do(
+				.WithStyle(NoticeStyleColors)
+				.Do(
 						() => {
-							if (ImGui.IsItemHovered()) {
-								ImGuiPlus.CreateTooltip(Strings.MainWindowNoticesAckTooltip);
-								_noticeAckButtonColor = DangerBgColor;
-							} else {
-								_noticeAckButtonColor = DangerFgColor;
-							}
+							var startedChildFrame = ImGui.BeginChildFrame(
+											ImGui.GetID("notice panel"),
+											_buttonSize.Value.WithY(_noticeFrameHeight.Value),
+											ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse | ImGuiWindowFlags.AlwaysAutoResize
+									);
+							if (!startedChildFrame) return;
+
+							ImGuiHelpers.CenteredText(Strings.MainWindowSectionLabelNotices);
+							ImGuiPlus
+											.WithStyle(ImGuiStyleVar.CellPadding, V2(0, 0))
+											.Do(
+													() => {
+													if (!ImGui.BeginTable("notices", 2, ImGuiTableFlags.SizingFixedFit))
+														return;
+
+													_notices.ForEach(
+																	notice => {
+																	ImGui.TableNextRow();
+																	ImGui.TableNextColumn();
+																	ImGui.Text(NoticeBulletChar);
+
+																	ImGui.TableNextColumn();
+																	ImGui.PushTextWrapPos(_noticeFrameWrap.Value + ImGui.GetCursorPosX());
+																	ImGui.TextWrapped(notice);
+																	ImGui.PopTextWrapPos();
+																}
+															);
+
+													ImGui.EndTable();
+												}
+											);
+
+							ImGui.Dummy(2 * V2(0, ImGui.GetStyle().ItemSpacing.Y));
+							ImGuiPlus
+											.WithStyle(ImGuiCol.Text, _noticeAckButtonColor)
+											.WithStyle(ImGuiStyleVar.FrameBorderSize, _noticeFrameBorderSize.Value)
+											.Do(
+													() => {
+													ImGui.SetCursorPos(_noticeAckButtonPos.Value);
+													if (!ImGui.Button(Strings.MainWindowNoticesAck)) return;
+
+													_conf.LastNoticeAcknowledged = DateTime.UtcNow;
+													_conf.Save();
+													_latestNoticesAreAcknowledged = true;
+												}
+											);
+							ImGuiPlus.WithStyle(ImGuiCol.Text, textColor).Do(
+											() => {
+											if (ImGui.IsItemHovered()) {
+												ImGuiPlus.CreateTooltip(Strings.MainWindowNoticesAckTooltip);
+												_noticeAckButtonColor = DangerBgColor;
+											} else {
+												_noticeAckButtonColor = DangerFgColor;
+											}
+										}
+									);
+
+							ImGui.EndChildFrame();
+
+							ImGuiPlus.Separator();
 						}
-					);
-
-					ImGui.EndChildFrame();
-
-					ImGuiPlus.Separator();
-				}
-			);
+				);
 	}
 
 	private void DrawModeButtons() {
@@ -297,12 +297,12 @@ public class MainWindow : Window, IDisposable {
 		if (ImGui.Button(Strings.BearButton, _buttonSize.Value)) {
 			_chat.TaggedPrint("Generating Bear link...");
 			GenerateLinkAsync(
-				train => _bearManager.GenerateBearLink(_clientState.WorldName(), train),
-				(trainList, bearTrainLink) => {
-					_chat.TaggedPrint($"Bear train link: {bearTrainLink.Url}");
-					_chat.TaggedPrint($"Train admin password: {bearTrainLink.Password}");
-					CopyLink(trainList, "bear", bearTrainLink.HighestPatch, bearTrainLink.Url);
-				}
+					train => _bearManager.GenerateBearLink(_clientState.WorldName(), train),
+					(trainList, bearTrainLink) => {
+						_chat.TaggedPrint($"Bear train link: {bearTrainLink.Url}");
+						_chat.TaggedPrint($"Train admin password: {bearTrainLink.Password}");
+						CopyLink(trainList, "bear", bearTrainLink.HighestPatch, bearTrainLink.Url);
+					}
 			);
 		}
 		if (ImGui.IsItemHovered()) ImGuiPlus.CreateTooltip(Strings.BearButtonTooltip);
@@ -310,13 +310,13 @@ public class MainWindow : Window, IDisposable {
 		if (ImGui.Button(Strings.SirenButton, _buttonSize.Value)) {
 			_chat.TaggedPrint("Generating Siren link...");
 			GenerateLink(
-				train => _sirenManager.GenerateSirenLink(train),
-				(trainList, sirenLink) => {
-					sirenLink
-						.ForEachError(errorMessage => _chat.TaggedPrintError(errorMessage))
-						.Value
-						.Execute(linkData => CopyLink(trainList, "siren", linkData.HighestPatch, linkData.Url));
-				}
+					train => _sirenManager.GenerateSirenLink(train),
+					(trainList, sirenLink) => {
+						sirenLink
+											.ForEachError(errorMessage => _chat.TaggedPrintError(errorMessage))
+											.Value
+											.Execute(linkData => CopyLink(trainList, "siren", linkData.HighestPatch, linkData.Url));
+					}
 			);
 		}
 		if (ImGui.IsItemHovered()) ImGuiPlus.CreateTooltip(Strings.SirenButtonTooltip);
@@ -343,14 +343,14 @@ public class MainWindow : Window, IDisposable {
 		};
 
 		var turtlePressed = ToggleButton.ButtonEx(
-			Strings.TurtleButton,
-			turtButtonSize,
-			ImGuiButtonFlags.MouseButtonDefault,
-			ImDrawFlags.RoundCornersLeft
+				Strings.TurtleButton,
+				turtButtonSize,
+				ImGuiButtonFlags.MouseButtonDefault,
+				ImDrawFlags.RoundCornersLeft
 		);
 		if (ImGui.IsItemHovered())
 			ImGuiPlus.CreateTooltip(
-				_turtleManager.IsTurtleCollabbing ? Strings.TurtleButtonActiveCollabTooltip : Strings.TurtleButtonTooltip
+					_turtleManager.IsTurtleCollabbing ? Strings.TurtleButtonActiveCollabTooltip : Strings.TurtleButtonTooltip
 			);
 		if (turtlePressed) {
 			if (_turtleManager.IsTurtleCollabbing) {
@@ -358,12 +358,12 @@ public class MainWindow : Window, IDisposable {
 			} else {
 				_chat.TaggedPrint("Generating Turtle link...");
 				GenerateLinkAsync(
-					train => _turtleManager.GenerateTurtleLink(train),
-					(trainList, turtleTrainLink) => {
-						_chat.TaggedPrint($"Turtle train link: {turtleTrainLink.ReadonlyUrl}");
-						_chat.TaggedPrint($"Turtle collaborate link: {turtleTrainLink.CollabUrl}");
-						CopyLink(trainList, "turtle", turtleTrainLink.HighestPatch, turtleTrainLink.ReadonlyUrl);
-					}
+						train => _turtleManager.GenerateTurtleLink(train),
+						(trainList, turtleTrainLink) => {
+							_chat.TaggedPrint($"Turtle train link: {turtleTrainLink.ReadonlyUrl}");
+							_chat.TaggedPrint($"Turtle collaborate link: {turtleTrainLink.CollabUrl}");
+							CopyLink(trainList, "turtle", turtleTrainLink.HighestPatch, turtleTrainLink.ReadonlyUrl);
+						}
 				);
 			}
 		}
@@ -371,18 +371,18 @@ public class MainWindow : Window, IDisposable {
 		ImGui.SameLine();
 		ImGui.SetCursorPosX(ImGui.GetCursorPosX() - itemSpacing.X + itemSpacing.Y);
 		var collabColor = _turtleManager.IsTurtleCollabbing
-			? *ImGui.GetStyleColorVec4(ImGuiCol.ButtonActive)
-			: *ImGui.GetStyleColorVec4(ImGuiCol.Button);
+				? *ImGui.GetStyleColorVec4(ImGuiCol.ButtonActive)
+				: *ImGui.GetStyleColorVec4(ImGuiCol.Button);
 		var turtleCollabPressed = ImGuiPlus
-			.WithStyle(ImGuiCol.Button, collabColor)
-			.Do(
-				() => ToggleButton.ButtonEx(
-					Strings.TurtleCollabButton,
-					turtCollabButtonSize,
-					ImGuiButtonFlags.MouseButtonDefault,
-					ImDrawFlags.RoundCornersRight
-				)
-			);
+				.WithStyle(ImGuiCol.Button, collabColor)
+				.Do(
+						() => ToggleButton.ButtonEx(
+								Strings.TurtleCollabButton,
+								turtCollabButtonSize,
+								ImGuiButtonFlags.MouseButtonDefault,
+								ImDrawFlags.RoundCornersRight
+						)
+				);
 		if (ImGui.IsItemHovered()) ImGuiPlus.CreateTooltip(Strings.TurtleCollabButtonTooltip);
 		if (turtleCollabPressed) ImGui.OpenPopup("turtle collab popup");
 	}
@@ -392,11 +392,11 @@ public class MainWindow : Window, IDisposable {
 		ImGui.PushTextWrapPos(contentWidth);
 
 		ImGuiPlus.Heading("SESSION", centered: true);
-		
+
 		ImGui.Checkbox("include name", ref _conf.IncludeNameInTurtleSession);
 		ImGui.SameLine();
 		ImGuiComponents.HelpMarker("share your character name in the turtle session, so others can see that you contributed.");
-		
+
 		ImGui.BeginDisabled(!_turtleManager.IsTurtleCollabbing);
 		if (ImGui.Button("LEAVE SESSION")) _turtleManager.LeaveCollabSession();
 		ImGui.EndDisabled();
@@ -406,20 +406,20 @@ public class MainWindow : Window, IDisposable {
 		ImGui.TextWrapped("start a new scout session on turtle for other scouters to join and contribute to.");
 		if (ImGui.Button("START NEW SESSION", _buttonSize.Value with { X = contentWidth })) {
 			_turtleManager
-				.GenerateTurtleLink(new List<TrainMob>(), allowEmpty: true)
-				.Then(
-					result => result.Match(
-						linkData => {
-							_collabInput = $"{linkData.Slug}/{linkData.CollabPassword}";
-							if (JoinTurtleCollabSession(_collabInput)) _closeTurtleCollabPopup = true;
-						},
-						errorMessage => _chat.TaggedPrintError(errorMessage)
-					)
-				);
+					.GenerateTurtleLink(new List<TrainMob>(), allowEmpty: true)
+					.Then(
+							result => result.Match(
+									linkData => {
+										_collabInput = $"{linkData.Slug}/{linkData.CollabPassword}";
+										if (JoinTurtleCollabSession(_collabInput)) _closeTurtleCollabPopup = true;
+									},
+									errorMessage => _chat.TaggedPrintError(errorMessage)
+							)
+					);
 		}
 		if (ImGui.IsItemHovered())
 			ImGuiPlus.CreateTooltip(
-				"generate a link to a new session, and immediately join it so you can start contributing. share the link with other scouters so they can also contribute :3"
+					"generate a link to a new session, and immediately join it so you can start contributing. share the link with other scouters so they can also contribute :3"
 			);
 
 		ImGuiPlus.Separator();
@@ -427,11 +427,11 @@ public class MainWindow : Window, IDisposable {
 		ImGui.TextWrapped("contribute scouted marks to an existing turtle session.");
 		ImGui.SetNextItemWidth(contentWidth - ImGuiHelpers.GetButtonSize("JOIN").X - ImGui.GetStyle().ItemSpacing.X);
 		var linkInputted = ImGui.InputTextWithHint(
-			"",
-			"https://scout.wobbuffet.net/scout/2WAZMI3DeZ/e5b2ede5",
-			ref _collabInput,
-			256,
-			ImGuiInputTextFlags.AutoSelectAll | ImGuiInputTextFlags.EnterReturnsTrue
+				"",
+				"https://scout.wobbuffet.net/scout/2WAZMI3DeZ/e5b2ede5",
+				ref _collabInput,
+				256,
+				ImGuiInputTextFlags.AutoSelectAll | ImGuiInputTextFlags.EnterReturnsTrue
 		);
 		if (ImGui.IsItemHovered())
 			ImGuiPlus.CreateTooltip("paste a collaborator link here and join the session to start contributing marks.");
@@ -449,14 +449,14 @@ public class MainWindow : Window, IDisposable {
 
 		_collabLink = "";
 		collabInfo
-			.Match(
-				sessionInfo => {
-					_collabLink = $"{_conf.TurtleBaseUrl}{_conf.TurtleTrainPath}/{sessionInfo.slug}/{sessionInfo.password}";
-					_chat.TaggedPrint($"joined turtle session: {_collabLink}");
-					_alreadyContributedMobs.Clear();
-				},
-				() => _chat.TaggedPrintError($"failed to parse collab link. please ensure it is a valid link.\n{collabLink}")
-			);
+				.Match(
+						sessionInfo => {
+							_collabLink = $"{_conf.TurtleBaseUrl}{_conf.TurtleTrainPath}/{sessionInfo.slug}/{sessionInfo.password}";
+							_chat.TaggedPrint($"joined turtle session: {_collabLink}");
+							_alreadyContributedMobs.Clear();
+						},
+						() => _chat.TaggedPrintError($"failed to parse collab link. please ensure it is a valid link.\n{collabLink}")
+				);
 
 		return collabInfo.HasValue;
 	}
@@ -464,75 +464,75 @@ public class MainWindow : Window, IDisposable {
 	private void PushLatestMobsToTurtle() {
 		// _chat.TaggedPrint($"Contributing marks to turtle session: {_collabLink}");
 		GetTrainMobs(out _)
-			.Map(
-				train => {
-					var trainSet = train.ToHashSet();
-					trainSet.RemoveWhere(mob => _alreadyContributedMobs.Contains(mob.GetHashCode()));
-					return trainSet.AsList();
-				}
-			)
-			.Tap(train => _chat.TaggedPrint($"pushing {train.Count} new marks to: {_collabInput}"))
-			.Bind(
-				train => _turtleManager.UpdateCurrentSession(train)
-					.Then(
-						updateStatus => {
-							if (updateStatus == TurtleHttpStatus.NoSupportedMobs)
-								_chat.TaggedPrint("no mobs supported by turtle were in the newest batch of mobs.");
-
-							return updateStatus is TurtleHttpStatus.Success or TurtleHttpStatus.NoSupportedMobs
-								? Result.Success<IList<TrainMob>, string>(train)
-								: "an error occurred while trying to update the marks in the current turtle session. please try again later.";
+				.Map(
+						train => {
+							var trainSet = train.ToHashSet();
+							trainSet.RemoveWhere(mob => _alreadyContributedMobs.Contains(mob.GetHashCode()));
+							return trainSet.AsList();
 						}
-					)
-			)
-			.Match(
-				train => {
-					train.ForEach(mob => _alreadyContributedMobs.Add(mob.GetHashCode()));
-					_chat.TaggedPrint("turtle session updated!");
-				},
-				errorMessage => _chat.TaggedPrintError(errorMessage)
-			)
-			.ContinueWith(
-				task => {
-					if (task.IsCompletedSuccessfully) return;
-					_log.Error(task.Exception, "uncaught exception when updating turtle session.");
-				}
-			);
+				)
+				.Tap(train => _chat.TaggedPrint($"pushing {train.Count} new marks to: {_collabInput}"))
+				.Bind(
+						train => _turtleManager.UpdateCurrentSession(train)
+								.Then(
+										updateStatus => {
+											if (updateStatus == TurtleHttpStatus.NoSupportedMobs)
+												_chat.TaggedPrint("no mobs supported by turtle were in the newest batch of mobs.");
+
+											return updateStatus is TurtleHttpStatus.Success or TurtleHttpStatus.NoSupportedMobs
+															? Result.Success<IList<TrainMob>, string>(train)
+															: "an error occurred while trying to update the marks in the current turtle session. please try again later.";
+										}
+								)
+				)
+				.Match(
+						train => {
+							train.ForEach(mob => _alreadyContributedMobs.Add(mob.GetHashCode()));
+							_chat.TaggedPrint("turtle session updated!");
+						},
+						errorMessage => _chat.TaggedPrintError(errorMessage)
+				)
+				.ContinueWith(
+						task => {
+							if (task.IsCompletedSuccessfully) return;
+							_log.Error(task.Exception, "uncaught exception when updating turtle session.");
+						}
+				);
 	}
 
 	private void GenerateLink<T>(
-		Func<List<TrainMob>, AccumulatedResults<T, string>> linkGenerator,
-		Action<IList<TrainMob>, AccumulatedResults<T, string>> onSuccess
+			Func<List<TrainMob>, AccumulatedResults<T, string>> linkGenerator,
+			Action<IList<TrainMob>, AccumulatedResults<T, string>> onSuccess
 	) {
 		GetTrainMobs(out var trainList)
-			.Map(linkGenerator)
-			.Match(
-				link => onSuccess(trainList, link),
-				errorMessage => _chat.TaggedPrintError(errorMessage)
-			);
+				.Map(linkGenerator)
+				.Match(
+						link => onSuccess(trainList, link),
+						errorMessage => _chat.TaggedPrintError(errorMessage)
+				);
 	}
 
 	private void GenerateLinkAsync<T>(
-		Func<List<TrainMob>, Task<Result<T, string>>> linkGenerator,
-		Action<IList<TrainMob>, T> onSuccess
+			Func<List<TrainMob>, Task<Result<T, string>>> linkGenerator,
+			Action<IList<TrainMob>, T> onSuccess
 	) {
 		GetTrainMobs(out var trainList)
-			.Bind(linkGenerator)
-			.Match(
-				link => onSuccess(trainList, link),
-				errorMessage => { _chat.TaggedPrintError(errorMessage); }
-			);
+				.Bind(linkGenerator)
+				.Match(
+						link => onSuccess(trainList, link),
+						errorMessage => { _chat.TaggedPrintError(errorMessage); }
+				);
 	}
 
 	private Result<List<TrainMob>, string> GetTrainMobs(out IList<TrainMob> trainList) {
 		var obtainedTrain = new List<TrainMob>();
 		var result = _huntHelperManager
-			.GetTrainList()
-			.Ensure(
-				train => train.IsNotEmpty(),
-				"No mobs in the train :T"
-			)
-			.Tap(mobs => obtainedTrain = mobs);
+				.GetTrainList()
+				.Ensure(
+						train => train.IsNotEmpty(),
+						"No mobs in the train :T"
+				)
+				.Tap(mobs => obtainedTrain = mobs);
 		trainList = obtainedTrain.AsList();
 		return result;
 	}
@@ -540,12 +540,12 @@ public class MainWindow : Window, IDisposable {
 	private void CopyLink(IList<TrainMob> trainList, string tracker, Patch highestPatch, string link) {
 		if (_isCopyModeFullText) {
 			var fullText = FormatTemplate(
-				_conf.CopyTemplate,
-				trainList,
-				tracker,
-				_clientState.WorldName(),
-				highestPatch,
-				link
+					_conf.CopyTemplate,
+					trainList,
+					tracker,
+					_clientState.WorldName(),
+					highestPatch,
+					link
 			);
 			ImGui.SetClipboardText(fullText);
 			_chat.TaggedPrint($"Copied full text to clipboard: {fullText}");

--- a/ScoutHelper/Windows/MainWindow.cs
+++ b/ScoutHelper/Windows/MainWindow.cs
@@ -32,12 +32,12 @@ public class MainWindow : Window, IDisposable {
 	private static readonly Vector4 DangerBgColor = Color(181, 0, 69);
 
 	private static readonly IList<(ImGuiCol, Vector4)> NoticeStyleColors = new[] {
-				(ImGuiCol.FrameBg, DangerBgColor),
-				(ImGuiCol.Button, DangerBgColor),
-				(ImGuiCol.ButtonHovered, DangerFgColor),
-				(ImGuiCol.Border, DangerFgColor),
-				(ImGuiCol.Text, DangerFgColor),
-		}.AsList();
+		(ImGuiCol.FrameBg, DangerBgColor),
+		(ImGuiCol.Button, DangerBgColor),
+		(ImGuiCol.ButtonHovered, DangerFgColor),
+		(ImGuiCol.Border, DangerFgColor),
+		(ImGuiCol.Text, DangerFgColor),
+	}.AsList();
 
 	private readonly IPluginLog _log;
 	private readonly IClientState _clientState;
@@ -68,18 +68,18 @@ public class MainWindow : Window, IDisposable {
 	private bool _closeTurtleCollabPopup = false;
 
 	public MainWindow(
-			IPluginLog log,
-			IClientState clientState,
-			Configuration conf,
-			IChatGui chat,
-			HuntHelperManager huntHelperManager,
-			BearManager bearManager,
-			SirenManager sirenManager,
-			TurtleManager turtleManager,
-			ConfigWindow configWindow
+		IPluginLog log,
+		IClientState clientState,
+		Configuration conf,
+		IChatGui chat,
+		HuntHelperManager huntHelperManager,
+		BearManager bearManager,
+		SirenManager sirenManager,
+		TurtleManager turtleManager,
+		ConfigWindow configWindow
 	) : base(
-			Strings.MainWindowTitle,
-			ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoScrollbar
+		Strings.MainWindowTitle,
+		ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoScrollbar
 	) {
 		_log = log;
 		_clientState = clientState;
@@ -99,71 +99,71 @@ public class MainWindow : Window, IDisposable {
 			MaximumSize = new Vector2(float.MaxValue, float.MaxValue),
 		};
 		TitleBarButtons.Add(
-				new TitleBarButton() {
-					Click = _ => _configWindow.IsOpen = true,
-					Icon = FontAwesomeIcon.Cog,
-					IconOffset = V2(2, 1),
-					ShowTooltip = () => ImGuiPlus.CreateTooltip("open the scout helper settings window"),
-				}
+			new TitleBarButton() {
+				Click = _ => _configWindow.IsOpen = true,
+				Icon = FontAwesomeIcon.Cog,
+				IconOffset = V2(2, 1),
+				ShowTooltip = () => ImGuiPlus.CreateTooltip("open the scout helper settings window"),
+			}
 		);
 
 		_buttonSize = new Lazy<Vector2>(
-				() => {
-					try {
-						var buttonSize = new[] {
-														[Strings.BearButton],
-														[Strings.SirenButton],
-														[Strings.TurtleButton, Strings.TurtleCollabButton],
-														new[] { Strings.CopyModeLinkButton, Strings.CopyModeFullTextButton, },
-										}
-										.Select(
-												labels => labels
-														.Select(ImGuiHelpers.GetButtonSize)
-														.Aggregate((a, b) => new Vector2(Math.Max(a.X, b.X), Math.Max(a.Y, b.Y)))
-										)
-										.MaxBy(size => size.X);
-						buttonSize.X += 4 * ImGui.GetFontSize(); // add some horizontal padding
-						return buttonSize;
-					} catch (Exception e) {
-						_log.Error(e, "error while determining button size.");
-						throw;
-					}
+			() => {
+				try {
+					var buttonSize = new[] {
+							[Strings.BearButton],
+							[Strings.SirenButton],
+							[Strings.TurtleButton, Strings.TurtleCollabButton],
+							new[] { Strings.CopyModeLinkButton, Strings.CopyModeFullTextButton, },
+						}
+						.Select(
+							labels => labels
+								.Select(ImGuiHelpers.GetButtonSize)
+								.Aggregate((a, b) => new Vector2(Math.Max(a.X, b.X), Math.Max(a.Y, b.Y)))
+						)
+						.MaxBy(size => size.X);
+					buttonSize.X += 4 * ImGui.GetFontSize(); // add some horizontal padding
+					return buttonSize;
+				} catch (Exception e) {
+					_log.Error(e, "error while determining button size.");
+					throw;
 				}
+			}
 		);
 
 		_notices = Constants.Notices;
 
 		_noticeFrameBorderSize = new Lazy<float>(() => ImGuiHelpers.GlobalScaleSafe * (NoticeHasBorder ? 1 : 0));
 		_noticeFrameWrap = new Lazy<float>(
-				() => new[] {
-								_buttonSize.Value.X,
-								-2 * ImGui.GetStyle().FramePadding.X,
-								-ImGui.CalcTextSize(NoticeBulletChar).X,
-				}.Sum()
+			() => new[] {
+				_buttonSize.Value.X,
+				-2 * ImGui.GetStyle().FramePadding.X,
+				-ImGui.CalcTextSize(NoticeBulletChar).X,
+			}.Sum()
 		);
 		var noticeAckButtonSize = new Lazy<Vector2>(() => ImGuiHelpers.GetButtonSize(Strings.MainWindowNoticesAck));
 		_noticeFrameHeight = new Lazy<float>(
-				() => new[] {
-								2 * ImGui.GetStyle().FramePadding.Y,
-								ImGui.CalcTextSize(Strings.MainWindowSectionLabelNotices).Y,
-								4 * ImGui.GetStyle().ItemSpacing.Y,
-								noticeAckButtonSize.Value.Y,
-								2 * _noticeFrameBorderSize.Value,
-								_notices
-										.Select(
-												notice =>
-														ImGui.CalcTextSize(notice, _noticeFrameWrap.Value).Y
-														+ ImGui.GetStyle().ItemSpacing.Y
-										)
-										.Sum(),
-				}.Sum()
+			() => new[] {
+				2 * ImGui.GetStyle().FramePadding.Y,
+				ImGui.CalcTextSize(Strings.MainWindowSectionLabelNotices).Y,
+				4 * ImGui.GetStyle().ItemSpacing.Y,
+				noticeAckButtonSize.Value.Y,
+				2 * _noticeFrameBorderSize.Value,
+				_notices
+					.Select(
+						notice =>
+							ImGui.CalcTextSize(notice, _noticeFrameWrap.Value).Y
+							+ ImGui.GetStyle().ItemSpacing.Y
+					)
+					.Sum(),
+			}.Sum()
 		);
 		_noticeAckButtonPos = new Lazy<Vector2>(
-				() => V2(
-						(_buttonSize.Value.X - noticeAckButtonSize.Value.X) / 2,
-						_noticeFrameHeight.Value - noticeAckButtonSize.Value.Y - ImGui.GetStyle().FramePadding.Y -
-						2 * _noticeFrameBorderSize.Value
-				)
+			() => V2(
+				(_buttonSize.Value.X - noticeAckButtonSize.Value.X) / 2,
+				_noticeFrameHeight.Value - noticeAckButtonSize.Value.Y - ImGui.GetStyle().FramePadding.Y -
+				2 * _noticeFrameBorderSize.Value
+			)
 		);
 
 		_latestNoticesAreAcknowledged = Constants.LatestNoticeUpdate < _conf.LastNoticeAcknowledged;
@@ -193,71 +193,71 @@ public class MainWindow : Window, IDisposable {
 		var textColor = *ImGui.GetStyleColorVec4(ImGuiCol.Text);
 
 		ImGuiPlus
-				.WithStyle(NoticeStyleColors)
-				.Do(
+			.WithStyle(NoticeStyleColors)
+			.Do(
+				() => {
+					var startedChildFrame = ImGui.BeginChildFrame(
+						ImGui.GetID("notice panel"),
+						_buttonSize.Value.WithY(_noticeFrameHeight.Value),
+						ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse | ImGuiWindowFlags.AlwaysAutoResize
+					);
+					if (!startedChildFrame) return;
+
+					ImGuiHelpers.CenteredText(Strings.MainWindowSectionLabelNotices);
+					ImGuiPlus
+						.WithStyle(ImGuiStyleVar.CellPadding, V2(0, 0))
+						.Do(
+							() => {
+								if (!ImGui.BeginTable("notices", 2, ImGuiTableFlags.SizingFixedFit))
+									return;
+
+								_notices.ForEach(
+									notice => {
+										ImGui.TableNextRow();
+										ImGui.TableNextColumn();
+										ImGui.Text(NoticeBulletChar);
+
+										ImGui.TableNextColumn();
+										ImGui.PushTextWrapPos(_noticeFrameWrap.Value + ImGui.GetCursorPosX());
+										ImGui.TextWrapped(notice);
+										ImGui.PopTextWrapPos();
+									}
+								);
+
+								ImGui.EndTable();
+							}
+						);
+
+					ImGui.Dummy(2 * V2(0, ImGui.GetStyle().ItemSpacing.Y));
+					ImGuiPlus
+						.WithStyle(ImGuiCol.Text, _noticeAckButtonColor)
+						.WithStyle(ImGuiStyleVar.FrameBorderSize, _noticeFrameBorderSize.Value)
+						.Do(
+							() => {
+								ImGui.SetCursorPos(_noticeAckButtonPos.Value);
+								if (!ImGui.Button(Strings.MainWindowNoticesAck)) return;
+
+								_conf.LastNoticeAcknowledged = DateTime.UtcNow;
+								_conf.Save();
+								_latestNoticesAreAcknowledged = true;
+							}
+						);
+					ImGuiPlus.WithStyle(ImGuiCol.Text, textColor).Do(
 						() => {
-							var startedChildFrame = ImGui.BeginChildFrame(
-											ImGui.GetID("notice panel"),
-											_buttonSize.Value.WithY(_noticeFrameHeight.Value),
-											ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse | ImGuiWindowFlags.AlwaysAutoResize
-									);
-							if (!startedChildFrame) return;
-
-							ImGuiHelpers.CenteredText(Strings.MainWindowSectionLabelNotices);
-							ImGuiPlus
-											.WithStyle(ImGuiStyleVar.CellPadding, V2(0, 0))
-											.Do(
-													() => {
-													if (!ImGui.BeginTable("notices", 2, ImGuiTableFlags.SizingFixedFit))
-														return;
-
-													_notices.ForEach(
-																	notice => {
-																	ImGui.TableNextRow();
-																	ImGui.TableNextColumn();
-																	ImGui.Text(NoticeBulletChar);
-
-																	ImGui.TableNextColumn();
-																	ImGui.PushTextWrapPos(_noticeFrameWrap.Value + ImGui.GetCursorPosX());
-																	ImGui.TextWrapped(notice);
-																	ImGui.PopTextWrapPos();
-																}
-															);
-
-													ImGui.EndTable();
-												}
-											);
-
-							ImGui.Dummy(2 * V2(0, ImGui.GetStyle().ItemSpacing.Y));
-							ImGuiPlus
-											.WithStyle(ImGuiCol.Text, _noticeAckButtonColor)
-											.WithStyle(ImGuiStyleVar.FrameBorderSize, _noticeFrameBorderSize.Value)
-											.Do(
-													() => {
-													ImGui.SetCursorPos(_noticeAckButtonPos.Value);
-													if (!ImGui.Button(Strings.MainWindowNoticesAck)) return;
-
-													_conf.LastNoticeAcknowledged = DateTime.UtcNow;
-													_conf.Save();
-													_latestNoticesAreAcknowledged = true;
-												}
-											);
-							ImGuiPlus.WithStyle(ImGuiCol.Text, textColor).Do(
-											() => {
-											if (ImGui.IsItemHovered()) {
-												ImGuiPlus.CreateTooltip(Strings.MainWindowNoticesAckTooltip);
-												_noticeAckButtonColor = DangerBgColor;
-											} else {
-												_noticeAckButtonColor = DangerFgColor;
-											}
-										}
-									);
-
-							ImGui.EndChildFrame();
-
-							ImGuiPlus.Separator();
+							if (ImGui.IsItemHovered()) {
+								ImGuiPlus.CreateTooltip(Strings.MainWindowNoticesAckTooltip);
+								_noticeAckButtonColor = DangerBgColor;
+							} else {
+								_noticeAckButtonColor = DangerFgColor;
+							}
 						}
-				);
+					);
+
+					ImGui.EndChildFrame();
+
+					ImGuiPlus.Separator();
+				}
+			);
 	}
 
 	private void DrawModeButtons() {
@@ -297,12 +297,12 @@ public class MainWindow : Window, IDisposable {
 		if (ImGui.Button(Strings.BearButton, _buttonSize.Value)) {
 			_chat.TaggedPrint("Generating Bear link...");
 			GenerateLinkAsync(
-					train => _bearManager.GenerateBearLink(_clientState.WorldName(), train),
-					(trainList, bearTrainLink) => {
-						_chat.TaggedPrint($"Bear train link: {bearTrainLink.Url}");
-						_chat.TaggedPrint($"Train admin password: {bearTrainLink.Password}");
-						CopyLink(trainList, "bear", bearTrainLink.HighestPatch, bearTrainLink.Url);
-					}
+				train => _bearManager.GenerateBearLink(_clientState.WorldName(), train),
+				(trainList, bearTrainLink) => {
+					_chat.TaggedPrint($"Bear train link: {bearTrainLink.Url}");
+					_chat.TaggedPrint($"Train admin password: {bearTrainLink.Password}");
+					CopyLink(trainList, "bear", bearTrainLink.HighestPatch, bearTrainLink.Url);
+				}
 			);
 		}
 		if (ImGui.IsItemHovered()) ImGuiPlus.CreateTooltip(Strings.BearButtonTooltip);
@@ -310,13 +310,13 @@ public class MainWindow : Window, IDisposable {
 		if (ImGui.Button(Strings.SirenButton, _buttonSize.Value)) {
 			_chat.TaggedPrint("Generating Siren link...");
 			GenerateLink(
-					train => _sirenManager.GenerateSirenLink(train),
-					(trainList, sirenLink) => {
-						sirenLink
-											.ForEachError(errorMessage => _chat.TaggedPrintError(errorMessage))
-											.Value
-											.Execute(linkData => CopyLink(trainList, "siren", linkData.HighestPatch, linkData.Url));
-					}
+				train => _sirenManager.GenerateSirenLink(train),
+				(trainList, sirenLink) => {
+					sirenLink
+						.ForEachError(errorMessage => _chat.TaggedPrintError(errorMessage))
+						.Value
+						.Execute(linkData => CopyLink(trainList, "siren", linkData.HighestPatch, linkData.Url));
+				}
 			);
 		}
 		if (ImGui.IsItemHovered()) ImGuiPlus.CreateTooltip(Strings.SirenButtonTooltip);
@@ -343,14 +343,14 @@ public class MainWindow : Window, IDisposable {
 		};
 
 		var turtlePressed = ToggleButton.ButtonEx(
-				Strings.TurtleButton,
-				turtButtonSize,
-				ImGuiButtonFlags.MouseButtonDefault,
-				ImDrawFlags.RoundCornersLeft
+			Strings.TurtleButton,
+			turtButtonSize,
+			ImGuiButtonFlags.MouseButtonDefault,
+			ImDrawFlags.RoundCornersLeft
 		);
 		if (ImGui.IsItemHovered())
 			ImGuiPlus.CreateTooltip(
-					_turtleManager.IsTurtleCollabbing ? Strings.TurtleButtonActiveCollabTooltip : Strings.TurtleButtonTooltip
+				_turtleManager.IsTurtleCollabbing ? Strings.TurtleButtonActiveCollabTooltip : Strings.TurtleButtonTooltip
 			);
 		if (turtlePressed) {
 			if (_turtleManager.IsTurtleCollabbing) {
@@ -358,12 +358,12 @@ public class MainWindow : Window, IDisposable {
 			} else {
 				_chat.TaggedPrint("Generating Turtle link...");
 				GenerateLinkAsync(
-						train => _turtleManager.GenerateTurtleLink(train),
-						(trainList, turtleTrainLink) => {
-							_chat.TaggedPrint($"Turtle train link: {turtleTrainLink.ReadonlyUrl}");
-							_chat.TaggedPrint($"Turtle collaborate link: {turtleTrainLink.CollabUrl}");
-							CopyLink(trainList, "turtle", turtleTrainLink.HighestPatch, turtleTrainLink.ReadonlyUrl);
-						}
+					train => _turtleManager.GenerateTurtleLink(train),
+					(trainList, turtleTrainLink) => {
+						_chat.TaggedPrint($"Turtle train link: {turtleTrainLink.ReadonlyUrl}");
+						_chat.TaggedPrint($"Turtle collaborate link: {turtleTrainLink.CollabUrl}");
+						CopyLink(trainList, "turtle", turtleTrainLink.HighestPatch, turtleTrainLink.ReadonlyUrl);
+					}
 				);
 			}
 		}
@@ -371,18 +371,18 @@ public class MainWindow : Window, IDisposable {
 		ImGui.SameLine();
 		ImGui.SetCursorPosX(ImGui.GetCursorPosX() - itemSpacing.X + itemSpacing.Y);
 		var collabColor = _turtleManager.IsTurtleCollabbing
-				? *ImGui.GetStyleColorVec4(ImGuiCol.ButtonActive)
-				: *ImGui.GetStyleColorVec4(ImGuiCol.Button);
+			? *ImGui.GetStyleColorVec4(ImGuiCol.ButtonActive)
+			: *ImGui.GetStyleColorVec4(ImGuiCol.Button);
 		var turtleCollabPressed = ImGuiPlus
-				.WithStyle(ImGuiCol.Button, collabColor)
-				.Do(
-						() => ToggleButton.ButtonEx(
-								Strings.TurtleCollabButton,
-								turtCollabButtonSize,
-								ImGuiButtonFlags.MouseButtonDefault,
-								ImDrawFlags.RoundCornersRight
-						)
-				);
+			.WithStyle(ImGuiCol.Button, collabColor)
+			.Do(
+				() => ToggleButton.ButtonEx(
+					Strings.TurtleCollabButton,
+					turtCollabButtonSize,
+					ImGuiButtonFlags.MouseButtonDefault,
+					ImDrawFlags.RoundCornersRight
+				)
+			);
 		if (ImGui.IsItemHovered()) ImGuiPlus.CreateTooltip(Strings.TurtleCollabButtonTooltip);
 		if (turtleCollabPressed) ImGui.OpenPopup("turtle collab popup");
 	}
@@ -395,7 +395,9 @@ public class MainWindow : Window, IDisposable {
 
 		ImGui.Checkbox("include name", ref _conf.IncludeNameInTurtleSession);
 		ImGui.SameLine();
-		ImGuiComponents.HelpMarker("share your character name in the turtle session, so others can see that you contributed.");
+		ImGuiComponents.HelpMarker(
+			"share your character name in the turtle session, so others can see that you contributed."
+		);
 
 		ImGui.BeginDisabled(!_turtleManager.IsTurtleCollabbing);
 		if (ImGui.Button("LEAVE SESSION")) _turtleManager.LeaveCollabSession();
@@ -406,20 +408,20 @@ public class MainWindow : Window, IDisposable {
 		ImGui.TextWrapped("start a new scout session on turtle for other scouters to join and contribute to.");
 		if (ImGui.Button("START NEW SESSION", _buttonSize.Value with { X = contentWidth })) {
 			_turtleManager
-					.GenerateTurtleLink(new List<TrainMob>(), allowEmpty: true)
-					.Then(
-							result => result.Match(
-									linkData => {
-										_collabInput = $"{linkData.Slug}/{linkData.CollabPassword}";
-										if (JoinTurtleCollabSession(_collabInput)) _closeTurtleCollabPopup = true;
-									},
-									errorMessage => _chat.TaggedPrintError(errorMessage)
-							)
-					);
+				.GenerateTurtleLink(new List<TrainMob>(), allowEmpty: true)
+				.Then(
+					result => result.Match(
+						linkData => {
+							_collabInput = $"{linkData.Slug}/{linkData.CollabPassword}";
+							if (JoinTurtleCollabSession(_collabInput)) _closeTurtleCollabPopup = true;
+						},
+						errorMessage => _chat.TaggedPrintError(errorMessage)
+					)
+				);
 		}
 		if (ImGui.IsItemHovered())
 			ImGuiPlus.CreateTooltip(
-					"generate a link to a new session, and immediately join it so you can start contributing. share the link with other scouters so they can also contribute :3"
+				"generate a link to a new session, and immediately join it so you can start contributing. share the link with other scouters so they can also contribute :3"
 			);
 
 		ImGuiPlus.Separator();
@@ -427,11 +429,11 @@ public class MainWindow : Window, IDisposable {
 		ImGui.TextWrapped("contribute scouted marks to an existing turtle session.");
 		ImGui.SetNextItemWidth(contentWidth - ImGuiHelpers.GetButtonSize("JOIN").X - ImGui.GetStyle().ItemSpacing.X);
 		var linkInputted = ImGui.InputTextWithHint(
-				"",
-				"https://scout.wobbuffet.net/scout/2WAZMI3DeZ/e5b2ede5",
-				ref _collabInput,
-				256,
-				ImGuiInputTextFlags.AutoSelectAll | ImGuiInputTextFlags.EnterReturnsTrue
+			"",
+			"https://scout.wobbuffet.net/scout/2WAZMI3DeZ/e5b2ede5",
+			ref _collabInput,
+			256,
+			ImGuiInputTextFlags.AutoSelectAll | ImGuiInputTextFlags.EnterReturnsTrue
 		);
 		if (ImGui.IsItemHovered())
 			ImGuiPlus.CreateTooltip("paste a collaborator link here and join the session to start contributing marks.");
@@ -449,14 +451,14 @@ public class MainWindow : Window, IDisposable {
 
 		_collabLink = "";
 		collabInfo
-				.Match(
-						sessionInfo => {
-							_collabLink = $"{_conf.TurtleBaseUrl}{_conf.TurtleTrainPath}/{sessionInfo.slug}/{sessionInfo.password}";
-							_chat.TaggedPrint($"joined turtle session: {_collabLink}");
-							_alreadyContributedMobs.Clear();
-						},
-						() => _chat.TaggedPrintError($"failed to parse collab link. please ensure it is a valid link.\n{collabLink}")
-				);
+			.Match(
+				sessionInfo => {
+					_collabLink = $"{_conf.TurtleBaseUrl}{_conf.TurtleTrainPath}/{sessionInfo.slug}/{sessionInfo.password}";
+					_chat.TaggedPrint($"joined turtle session: {_collabLink}");
+					_alreadyContributedMobs.Clear();
+				},
+				() => _chat.TaggedPrintError($"failed to parse collab link. please ensure it is a valid link.\n{collabLink}")
+			);
 
 		return collabInfo.HasValue;
 	}
@@ -464,75 +466,75 @@ public class MainWindow : Window, IDisposable {
 	private void PushLatestMobsToTurtle() {
 		// _chat.TaggedPrint($"Contributing marks to turtle session: {_collabLink}");
 		GetTrainMobs(out _)
-				.Map(
-						train => {
-							var trainSet = train.ToHashSet();
-							trainSet.RemoveWhere(mob => _alreadyContributedMobs.Contains(mob.GetHashCode()));
-							return trainSet.AsList();
-						}
-				)
-				.Tap(train => _chat.TaggedPrint($"pushing {train.Count} new marks to: {_collabInput}"))
-				.Bind(
-						train => _turtleManager.UpdateCurrentSession(train)
-								.Then(
-										updateStatus => {
-											if (updateStatus == TurtleHttpStatus.NoSupportedMobs)
-												_chat.TaggedPrint("no mobs supported by turtle were in the newest batch of mobs.");
+			.Map(
+				train => {
+					var trainSet = train.ToHashSet();
+					trainSet.RemoveWhere(mob => _alreadyContributedMobs.Contains(mob.GetHashCode()));
+					return trainSet.AsList();
+				}
+			)
+			.Tap(train => _chat.TaggedPrint($"pushing {train.Count} new marks to: {_collabInput}"))
+			.Bind(
+				train => _turtleManager.UpdateCurrentSession(train)
+					.Then(
+						updateStatus => {
+							if (updateStatus == TurtleHttpStatus.NoSupportedMobs)
+								_chat.TaggedPrint("no mobs supported by turtle were in the newest batch of mobs.");
 
-											return updateStatus is TurtleHttpStatus.Success or TurtleHttpStatus.NoSupportedMobs
-															? Result.Success<IList<TrainMob>, string>(train)
-															: "an error occurred while trying to update the marks in the current turtle session. please try again later.";
-										}
-								)
-				)
-				.Match(
-						train => {
-							train.ForEach(mob => _alreadyContributedMobs.Add(mob.GetHashCode()));
-							_chat.TaggedPrint("turtle session updated!");
-						},
-						errorMessage => _chat.TaggedPrintError(errorMessage)
-				)
-				.ContinueWith(
-						task => {
-							if (task.IsCompletedSuccessfully) return;
-							_log.Error(task.Exception, "uncaught exception when updating turtle session.");
+							return updateStatus is TurtleHttpStatus.Success or TurtleHttpStatus.NoSupportedMobs
+								? Result.Success<IList<TrainMob>, string>(train)
+								: "an error occurred while trying to update the marks in the current turtle session. please try again later.";
 						}
-				);
+					)
+			)
+			.Match(
+				train => {
+					train.ForEach(mob => _alreadyContributedMobs.Add(mob.GetHashCode()));
+					_chat.TaggedPrint("turtle session updated!");
+				},
+				errorMessage => _chat.TaggedPrintError(errorMessage)
+			)
+			.ContinueWith(
+				task => {
+					if (task.IsCompletedSuccessfully) return;
+					_log.Error(task.Exception, "uncaught exception when updating turtle session.");
+				}
+			);
 	}
 
 	private void GenerateLink<T>(
-			Func<List<TrainMob>, AccumulatedResults<T, string>> linkGenerator,
-			Action<IList<TrainMob>, AccumulatedResults<T, string>> onSuccess
+		Func<List<TrainMob>, AccumulatedResults<T, string>> linkGenerator,
+		Action<IList<TrainMob>, AccumulatedResults<T, string>> onSuccess
 	) {
 		GetTrainMobs(out var trainList)
-				.Map(linkGenerator)
-				.Match(
-						link => onSuccess(trainList, link),
-						errorMessage => _chat.TaggedPrintError(errorMessage)
-				);
+			.Map(linkGenerator)
+			.Match(
+				link => onSuccess(trainList, link),
+				errorMessage => _chat.TaggedPrintError(errorMessage)
+			);
 	}
 
 	private void GenerateLinkAsync<T>(
-			Func<List<TrainMob>, Task<Result<T, string>>> linkGenerator,
-			Action<IList<TrainMob>, T> onSuccess
+		Func<List<TrainMob>, Task<Result<T, string>>> linkGenerator,
+		Action<IList<TrainMob>, T> onSuccess
 	) {
 		GetTrainMobs(out var trainList)
-				.Bind(linkGenerator)
-				.Match(
-						link => onSuccess(trainList, link),
-						errorMessage => { _chat.TaggedPrintError(errorMessage); }
-				);
+			.Bind(linkGenerator)
+			.Match(
+				link => onSuccess(trainList, link),
+				errorMessage => { _chat.TaggedPrintError(errorMessage); }
+			);
 	}
 
 	private Result<List<TrainMob>, string> GetTrainMobs(out IList<TrainMob> trainList) {
 		var obtainedTrain = new List<TrainMob>();
 		var result = _huntHelperManager
-				.GetTrainList()
-				.Ensure(
-						train => train.IsNotEmpty(),
-						"No mobs in the train :T"
-				)
-				.Tap(mobs => obtainedTrain = mobs);
+			.GetTrainList()
+			.Ensure(
+				train => train.IsNotEmpty(),
+				"No mobs in the train :T"
+			)
+			.Tap(mobs => obtainedTrain = mobs);
 		trainList = obtainedTrain.AsList();
 		return result;
 	}
@@ -540,12 +542,12 @@ public class MainWindow : Window, IDisposable {
 	private void CopyLink(IList<TrainMob> trainList, string tracker, Patch highestPatch, string link) {
 		if (_isCopyModeFullText) {
 			var fullText = FormatTemplate(
-					_conf.CopyTemplate,
-					trainList,
-					tracker,
-					_clientState.WorldName(),
-					highestPatch,
-					link
+				_conf.CopyTemplate,
+				trainList,
+				tracker,
+				_clientState.WorldName(),
+				highestPatch,
+				link
 			);
 			ImGui.SetClipboardText(fullText);
 			_chat.TaggedPrint($"Copied full text to clipboard: {fullText}");


### PR DESCRIPTION
The Hunt Helper IPC sometimes misses A ranks in it's IPC so I think it is worthwhile to check for A rank mobs ourself.

This leaves the Hunt Helper IPC in place to load hunt trains from HH's hunt train recorder (which seems to work I didn't test it extensively) for bear and turtle non-session.

Only when in a turtle collab session the object table is checked regularly for the presence of A ranks, an A rank is only transmitted to turtle once (transmitting it in every check interval is much too spammy)

This could probably be improved to cache A ranks should turtle not answer with a success (HTTP 200 and the expected response body probably) in the future.

I've tested this on several servers scouting ShB and EW marks.